### PR TITLE
Fix compilation issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@
 # Data files
 *.dat
 
+# Build directory
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required (VERSION 3.9)
+
+project(roulattice
+  DESCRIPTION "TODO"
+  LANGUAGES C
+)
+
+find_package(GDAL)
+find_package(OpenMP)
+find_package(MPI)
+
+add_executable(roulattice
+  src/bricks.c
+  src/checks.c
+  src/entropy.c
+  src/getArgs.c
+  src/intra_potential.c
+  src/license.c
+  src/main.c
+  src/observables.c
+  src/output.c
+  src/pair_correlation_function.c
+  src/random_knuth.c
+  src/read_dcd.c
+  src/SASA.c
+  src/statistics.c
+  src/tetra_bsaw1.c
+  src/tetra_bsaw2.c
+  src/tetra_bsaw3.c
+  src/tetra_fbsaw1.c
+  src/tetra_fbsaw2.c
+  src/tetra_fbsaw3.c
+  src/tetra_fsaw1.c
+  src/tetra_fsaw2.c
+  src/tetra_fsaw3.c
+  src/tetra_fww.c
+  src/tetra_rw.c
+  src/tetra_saw1.c
+  src/tetra_saw2.c
+  src/tetra_saw3.c
+  src/time.c
+)
+target_compile_options(roulattice PRIVATE -Wall) # -fsanitize=address)
+target_compile_features(roulattice PRIVATE c_std_99)
+target_include_directories(roulattice PUBLIC include)
+target_link_libraries(roulattice PRIVATE m)
+# target_link_options(roulattice PRIVATE -fsanitize=address)

--- a/README.md
+++ b/README.md
@@ -3,36 +3,38 @@ Creation and Evaluation of Linear Polymer Chains on the Tetrahedral Lattice
 
 Roulattice is a command line operated program that creates polymer conformations on the fly and analyzes them. The program can generate chains ensembles of different types: non-self-avoiding and self-avoiding walks, where there exist different hierarchies of self-avoidance. A detailed description of the walks can be found in Dietschreit, J. et al., Marocmol. Theory Simul., 2014, 23, 452-463.
 
+The library's code has been modernized by Richard Barnes (@r-barnes).
+
 
 # Getting Started
 
 Get the source code of Roulattice from the GitHub repository:
 
-$ git clone --recursive https://github.com/Roulattice/Roulattice
-  
+```bash
+git clone https://github.com/r-barnes/Roulattice
+```
+
 Or by downloading the ZIP-file of the whole repository. Unpack (if neccessary) the files at any chosen location of the computer. Change into the directory and compille the programm:
 
-  $ cd Roulattice
+```bash
+cd Roulattice
+```
 
-The program is divided into many files which are compiled to the main program using the present MAKEFILE. Type "make Roulattice" to get an executable named 'Roulattice'. 
+The program is divided into many files which are compiled to the main program using CMake. To build the program type:
 
-  $ make Roulattice
-
-Be sure to have the standard GCC-Compiler and all standard libraries installed. Any non-standard library is included in the folder 'include'. The MAKEFILE contains two lines with flags for the compiler depending on the system you wish to compile it on. Before you compile the programm make sure to comment the line with a hash, which does not suit your operating system (the flag "-lm" is needed if running on linux, whereas is has to be removed on MacOS X).  
+```bash
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+make
+```
 
 # Using Roulattice
 
 A publication history is displayed when using "-info". The license under which the programm is published will be displayed when using "-license". A complete list of options is shown when using the either "-h", "--help", or when the input was incorrect. Generally Roulattice is used as follows:
 
-$ ./Roulattice -tetra_saw1 50 -num 1000 
+```bash
+./roulattice -tetra_saw1 50 -num 1000 -torsion
+```
 
 Where '-tetra_saw1' specifies the walk used by the programm, '50' the number of atoms of the polymer chain, '-num' the ensemble size of generted confomations, and '1000' is the ensemble size. Further flags might be neccessary dependeing on the chosen type of run. There are also options regarding the observables which can be computed with the programm as well as options regarding the nature of the polymer. See the full option list as explained above.
-
-# Ubuntu
-
-On Ubuntu 14.04 you can install Git like this:
-
-$ sudo apt-get install git
-
-
-

--- a/include/SASA.h
+++ b/include/SASA.h
@@ -23,7 +23,7 @@
 #ifndef ____SASA__
 #define ____SASA__
 
-double pi;
+extern double pi;
 
 double get_asa(double (**chain), unsigned int numberofbeads, double r);
 

--- a/include/endianswap.h
+++ b/include/endianswap.h
@@ -16,7 +16,7 @@
  * DESCRIPTION:
  *   Byte swapping routines used in various plugins
  *   There are two versions of each routine, one that's safe to use in
- *   all cases (but is slow) and one that is only safe to use on memory 
+ *   all cases (but is slow) and one that is only safe to use on memory
  *   addresses that are aligned to the word size that's being byte-swapped
  *   but are much much much faster.  Use the aligned versions of these
  *   routines whenever possible.  The 'ndata' length count parameters and
@@ -29,17 +29,17 @@
 #define ENDIAN_SWAP_H
 
 /* works on unaligned 2-byte quantities */
-static void swap2_unaligned(void *v, long ndata) {
-  long i;
-  char * dataptr = (char *) v;
-  char tmp;
+// static void swap2_unaligned(void *v, long ndata) {
+//   long i;
+//   char * dataptr = (char *) v;
+//   char tmp;
 
-  for (i = 0; i < ndata-1; i += 2) {
-    tmp = dataptr[i];
-    dataptr[i] = dataptr[i+1];
-    dataptr[i+1] = tmp;
-  }
-}
+//   for (i = 0; i < ndata-1; i += 2) {
+//     tmp = dataptr[i];
+//     dataptr[i] = dataptr[i+1];
+//     dataptr[i+1] = tmp;
+//   }
+// }
 
 
 /* works on unaligned 4-byte quantities */
@@ -48,7 +48,7 @@ static void swap4_unaligned(void *v, long ndata) {
   char *dataptr;
   char tmp;
 
-  dataptr = (char *) v; 
+  dataptr = (char *) v;
   for (i=0; i<ndata; i++) {
     tmp = dataptr[0];
     dataptr[0] = dataptr[3];
@@ -93,16 +93,16 @@ static void swap8_unaligned(void *v, long ndata) {
 
 /* Only works with aligned 2-byte quantities, will cause a bus error */
 /* on some platforms if used on unaligned data.                      */
-static void swap2_aligned(void *v, long ndata) {
-  short *data = (short *) v;
-  long i;
-  short *N; 
+// static void swap2_aligned(void *v, long ndata) {
+//   short *data = (short *) v;
+//   long i;
+//   short *N;
 
-  for (i=0; i<ndata; i++) {
-    N = data + i;
-    *N=(((*N>>8)&0xff) | ((*N&0xff)<<8));  
-  }
-}
+//   for (i=0; i<ndata; i++) {
+//     N = data + i;
+//     *N=(((*N>>8)&0xff) | ((*N&0xff)<<8));
+//   }
+// }
 
 
 /* Only works with aligned 4-byte quantities, will cause a bus error */
@@ -113,7 +113,7 @@ static void swap4_aligned(void *v, long ndata) {
   int *N;
   for (i=0; i<ndata; i++) {
     N = data + i;
-    *N=(((*N>>24)&0xff) | ((*N&0xff)<<24) | 
+    *N=(((*N>>24)&0xff) | ((*N&0xff)<<24) |
         ((*N>>8)&0xff00) | ((*N&0xff00)<<8));
   }
 }
@@ -125,23 +125,23 @@ static void swap8_aligned(void *v, long ndata) {
   /* Use int* internally to prevent bugs caused by some compilers */
   /* and hardware that would potentially load data into an FP reg */
   /* and hose everything, such as the old "jmemcpy()" bug in NAMD */
-  int *data = (int *) v;  
+  int *data = (int *) v;
   long i;
-  int *N; 
+  int *N;
   int t0, t1;
 
   for (i=0; i<ndata; i++) {
     N = data + (i<<1);
     t0 = N[0];
-    t0=(((t0>>24)&0xff) | ((t0&0xff)<<24) | 
+    t0=(((t0>>24)&0xff) | ((t0&0xff)<<24) |
         ((t0>>8)&0xff00) | ((t0&0xff00)<<8));
 
     t1 = N[1];
-    t1=(((t1>>24)&0xff) | ((t1&0xff)<<24) | 
+    t1=(((t1>>24)&0xff) | ((t1&0xff)<<24) |
         ((t1>>8)&0xff00) | ((t1&0xff00)<<8));
 
-    N[0] = t1; 
-    N[1] = t0; 
+    N[0] = t1;
+    N[1] = t0;
   }
 }
 
@@ -170,4 +170,3 @@ void mdio_swap8(double *i) {
 #endif
 
 #endif
-

--- a/include/fastio.h
+++ b/include/fastio.h
@@ -25,7 +25,7 @@
 /* Compiling on windows */
 #if defined(_MSC_VER)
 
-#if 1 
+#if 1
 /* use native Windows I/O calls */
 #define FASTIO_NATIVEWIN32 1
 
@@ -52,10 +52,10 @@ typedef struct {
 static int fio_win32convertfilename(const char *filename, char *newfilename, int maxlen) {
   int i;
   int len=strlen(filename);
- 
+
   if ((len + 1) >= maxlen)
     return -1;
-   
+
   for (i=0; i<len; i++) {
     if (filename[i] == '/')
       newfilename[i] = '\\';
@@ -77,7 +77,7 @@ static int fio_open(const char *filename, int mode, fio_fd *fd) {
   DWORD flags;
 
   if (fio_win32convertfilename(filename, winfilename, sizeof(winfilename)))
-    return -1;  
+    return -1;
 
   access = 0;
   if (mode & FIO_READ)
@@ -94,12 +94,12 @@ static int fio_open(const char *filename, int mode, fio_fd *fd) {
   /* since we never append, blow away anything that's already there */
   if (mode & FIO_WRITE)
     createmode = CREATE_ALWAYS;
-  else 
+  else
     createmode = OPEN_EXISTING;
 
   flags = FILE_ATTRIBUTE_NORMAL;
 
-  fp = CreateFile(winfilename, access, sharing, security, 
+  fp = CreateFile(winfilename, access, sharing, security,
                   createmode, flags, NULL);
 
   if (fp == NULL) {
@@ -114,13 +114,13 @@ static int fio_open(const char *filename, int mode, fio_fd *fd) {
 static int fio_fclose(fio_fd fd) {
   BOOL rc;
   rc = CloseHandle(fd);
-  if (rc) 
+  if (rc)
     return 0;
-  else 
+  else
     return -1;
 }
 
-static fio_size_t fio_fread(void *ptr, fio_size_t size, 
+static fio_size_t fio_fread(void *ptr, fio_size_t size,
                             fio_size_t nitems, fio_fd fd) {
   BOOL rc;
   DWORD len;
@@ -132,7 +132,7 @@ static fio_size_t fio_fread(void *ptr, fio_size_t size,
   if (rc) {
     if (readlen == len)
       return nitems;
-    else 
+    else
       return 0;
   } else {
     return 0;
@@ -141,7 +141,7 @@ static fio_size_t fio_fread(void *ptr, fio_size_t size,
 
 static fio_size_t fio_readv(fio_fd fd, const fio_iovec * iov, int iovcnt) {
   int i;
-  fio_size_t len = 0; 
+  fio_size_t len = 0;
 
   for (i=0; i<iovcnt; i++) {
     fio_size_t rc = fio_fread(iov[i].iov_base, iov[i].iov_len, 1, fd);
@@ -153,14 +153,14 @@ static fio_size_t fio_readv(fio_fd fd, const fio_iovec * iov, int iovcnt) {
   return len;
 }
 
-static fio_size_t fio_fwrite(void *ptr, fio_size_t size, 
+static fio_size_t fio_fwrite(void *ptr, fio_size_t size,
                              fio_size_t nitems, fio_fd fd) {
   BOOL rc;
   DWORD len;
   DWORD writelen;
 
-  len = size * nitems; 
- 
+  len = size * nitems;
+
   rc = WriteFile(fd, ptr, len, &writelen, NULL);
   if (rc) {
     if (writelen == len)
@@ -190,7 +190,7 @@ static fio_size_t fio_fseek(fio_fd fd, fio_size_t offset, int whence) {
     if (GetLastError() != ERROR_SUCCESS) {
       return -1;
     }
-  } 
+  }
 
   finaloffset = finalint.QuadPart;
   return 0;
@@ -201,7 +201,7 @@ static fio_size_t fio_fseek(fio_fd fd, fio_size_t offset, int whence) {
   /* SetFilePointerEx() only exists with new .NET compilers */
   rc = SetFilePointerEx(fd, offset, &finaloffset, whence);
 
-  if (rc) 
+  if (rc)
     return 0;
   else
     return -1;
@@ -259,11 +259,11 @@ typedef struct {
 static int fio_open(const char *filename, int mode, fio_fd *fd) {
   char * modestr;
   FILE *fp;
- 
-  if (mode == FIO_READ) 
+
+  if (mode == FIO_READ)
     modestr = "rb";
 
-  if (mode == FIO_WRITE) 
+  if (mode == FIO_WRITE)
     modestr = "wb";
 
   fp = fopen(filename, modestr);
@@ -279,14 +279,14 @@ static int fio_fclose(fio_fd fd) {
   return fclose(fd);
 }
 
-static fio_size_t fio_fread(void *ptr, fio_size_t size, 
+static fio_size_t fio_fread(void *ptr, fio_size_t size,
                             fio_size_t nitems, fio_fd fd) {
   return fread(ptr, size, nitems, fd);
 }
 
 static fio_size_t fio_readv(fio_fd fd, const fio_iovec * iov, int iovcnt) {
   int i;
-  fio_size_t len = 0; 
+  fio_size_t len = 0;
 
   for (i=0; i<iovcnt; i++) {
     fio_size_t rc = fread(iov[i].iov_base, iov[i].iov_len, 1, fd);
@@ -298,7 +298,7 @@ static fio_size_t fio_readv(fio_fd fd, const fio_iovec * iov, int iovcnt) {
   return len;
 }
 
-static fio_size_t fio_fwrite(void *ptr, fio_size_t size, 
+static fio_size_t fio_fwrite(void *ptr, fio_size_t size,
                              fio_size_t nitems, fio_fd fd) {
   return fwrite(ptr, size, nitems, fd);
 }
@@ -312,7 +312,7 @@ static fio_size_t fio_ftell(fio_fd fd) {
 }
 #endif /* plain ANSI C */
 
-#else 
+#else
 
 /* Version for UNIX machines */
 #include <unistd.h>
@@ -353,10 +353,10 @@ static int fio_open(const char *filename, int mode, fio_fd *fd) {
   int nfd;
   int oflag = 0;
 
-  if (mode == FIO_READ) 
+  if (mode == FIO_READ)
     oflag = O_RDONLY;
 
-  if (mode == FIO_WRITE) 
+  if (mode == FIO_WRITE)
     oflag = O_WRONLY | O_CREAT | O_TRUNC;
 
   nfd = open(filename, oflag, 0666);
@@ -372,10 +372,10 @@ static int fio_fclose(fio_fd fd) {
   return close(fd);
 }
 
-static fio_size_t fio_fread(void *ptr, fio_size_t size, 
+static fio_size_t fio_fread(void *ptr, fio_size_t size,
                             fio_size_t nitems, fio_fd fd) {
   int i;
-  fio_size_t len = 0; 
+  fio_size_t len = 0;
   int cnt = 0;
 
   for (i=0; i<nitems; i++) {
@@ -394,7 +394,7 @@ static fio_size_t fio_readv(fio_fd fd, const fio_iovec * iov, int iovcnt) {
   return readv(fd, iov, iovcnt);
 #else
   int i;
-  fio_size_t len = 0; 
+  fio_size_t len = 0;
 
   for (i=0; i<iovcnt; i++) {
     fio_size_t rc = read(fd, iov[i].iov_base, iov[i].iov_len);
@@ -407,27 +407,27 @@ static fio_size_t fio_readv(fio_fd fd, const fio_iovec * iov, int iovcnt) {
 #endif
 }
 
-static fio_size_t fio_fwrite(void *ptr, fio_size_t size, 
-                             fio_size_t nitems, fio_fd fd) {
-  int i;
-  fio_size_t len = 0; 
-  int cnt = 0;
+// static fio_size_t fio_fwrite(void *ptr, fio_size_t size,
+//                              fio_size_t nitems, fio_fd fd) {
+//   int i;
+//   fio_size_t len = 0;
+//   int cnt = 0;
 
-  for (i=0; i<nitems; i++) {
-    fio_size_t rc = write(fd, ptr, size);
-    if (rc != size)
-      break;
-    len += rc;
-    cnt++;
-  }
+//   for (i=0; i<nitems; i++) {
+//     fio_size_t rc = write(fd, ptr, size);
+//     if (rc != size)
+//       break;
+//     len += rc;
+//     cnt++;
+//   }
 
-  return cnt;
-}
+//   return cnt;
+// }
 
 static fio_size_t fio_fseek(fio_fd fd, fio_size_t offset, int whence) {
  if (lseek(fd, offset, whence) >= 0)
    return 0;  /* success (emulate behavior of fseek) */
- else 
+ else
    return -1; /* failure (emulate behavior of fseek) */
 }
 
@@ -440,6 +440,7 @@ static fio_size_t fio_ftell(fio_fd fd) {
 
 /* higher level routines that are OS independent */
 
+/*
 static int fio_write_int32(fio_fd fd, int i) {
   return (fio_fwrite(&i, 4, 1, fd) != 1);
 }
@@ -452,4 +453,4 @@ static int fio_write_str(fio_fd fd, const char *str) {
   int len = strlen(str);
   return (fio_fwrite((void *) str, len, 1, fd) != 1);
 }
-
+*/

--- a/include/getArgs.h
+++ b/include/getArgs.h
@@ -30,26 +30,26 @@ void print_set_options(FILE *output_ptr, int typeofrun, int flength, int fflengt
 
 
 // initializing the global variables, which will be set in this routine
-int ARG_typeofrun;      // sets method
-int ARG_strictness;     // degree of self-avoidance
-int ARG_blength;        // sets bricklength
-int ARG_flength;        // sets fragment length
+extern int ARG_typeofrun;      // sets method
+extern int ARG_strictness;     // degree of self-avoidance
+extern int ARG_blength;        // sets bricklength
+extern int ARG_flength;        // sets fragment length
 
-long ARG_randomseed;
+extern long ARG_randomseed;
 
-unsigned int ARG_numberofbeads;     // number of atoms in chain
-unsigned long ARG_numberofframes;    // number  of chains that will be generated successfully
+extern unsigned int ARG_numberofbeads;     // number of atoms in chain
+extern unsigned long ARG_numberofframes;    // number  of chains that will be generated successfully
 
 //optional variables
-double ARG_bondlength;  // bond length
-int ARG_torsion;        // switch for torsional analysis
-int ARG_pair_correlation;
-int ARG_intra_potential; // switch for intra molecular potential
-double ARG_intra_parameter1[2];
-double ARG_intra_parameter2[2];
+extern double ARG_bondlength;  // bond length
+extern int ARG_torsion;        // switch for torsional analysis
+extern int ARG_pair_correlation;
+extern int ARG_intra_potential; // switch for intra molecular potential
+extern double ARG_intra_parameter1[2];
+extern double ARG_intra_parameter2[2];
 
 
-char* dcdFileName; // name of the dcd file which is to be loaded instead of a generation run
+extern char* dcdFileName; // name of the dcd file which is to be loaded instead of a generation run
 
 
 #endif /* defined(____getArgs__) */

--- a/include/observables.h
+++ b/include/observables.h
@@ -24,8 +24,8 @@
 #define ____observables__
 
 // global variables
-int ARG_blength;
-double pi;
+extern double pi;
+extern int ARG_blength;        // sets bricklength
 
 typedef struct {
     double ee2;
@@ -35,15 +35,15 @@ typedef struct {
     double dsasa;
     double *pair_corr;
     double S;
-    
-    
+
+
     double *err_ee2;
     double *err_rgyr;
     double *err_pt;
     double *err_dsasa;
     double err_S;
-    
-    
+
+
 }OBSERVABLE;
 
 

--- a/include/pair_correlation_function.h
+++ b/include/pair_correlation_function.h
@@ -23,7 +23,7 @@
 #ifndef ____pair_correlation_function__
 #define ____pair_correlation_function__
 
-double pi;
+extern double pi;
 
 int pair_correlation_fct(double (*corr_hist), double (**poly_ptr), const unsigned int numberofbeads);
 

--- a/include/read_dcd.h
+++ b/include/read_dcd.h
@@ -88,28 +88,28 @@ typedef struct{
 
 void subString(const char *source, int begin, int end, char *destination);
 
-static void print_dcderror(const char *func, int errcode);
+void print_dcderror(const char *func, int errcode);
 
-static int read_dcdheader(fio_fd fd, int *N, int *NSET, int *ISTART,
+int read_dcdheader(fio_fd fd, int *N, int *NSET, int *ISTART,
                           int *NSAVC, double *DELTA, int *NAMNF,
                           int **FREEINDEXES, float **fixedcoords, int *reverseEndian,
                           int *charmm);
 
-static int read_charmm_extrablock(fio_fd fd, int charmm, int reverseEndian,
+int read_charmm_extrablock(fio_fd fd, int charmm, int reverseEndian,
                                   float *unitcell);
 
-static int read_fixed_atoms(fio_fd fd, int N, int num_free, const int *indexes,
+int read_fixed_atoms(fio_fd fd, int N, int num_free, const int *indexes,
                             int reverseEndian, const float *fixedcoords,
                             float *freeatoms, float *pos, int charmm);
 
-static int read_charmm_4dim(fio_fd fd, int charmm, int reverseEndian);
+int read_charmm_4dim(fio_fd fd, int charmm, int reverseEndian);
 
-static int read_dcdstep(fio_fd fd, int N, float *X, float *Y, float *Z,
+int read_dcdstep(fio_fd fd, int N, float *X, float *Y, float *Z,
                         float *unitcell, int num_fixed,
                         int first, int *indexes, float *fixedcoords,
                         int reverseEndian, int charmm);
 
-static int skip_dcdstep(fio_fd fd, int natoms, int nfixed, int charmm);
+int skip_dcdstep(fio_fd fd, int natoms, int nfixed, int charmm);
 
 // static int write_dcdstep(fio_fd fd, int curframe, int curstep, int N, const float *X, const float *Y, const float *Z, const double *unitcell, int charmm);
 

--- a/include/tetra_bsaw1.h
+++ b/include/tetra_bsaw1.h
@@ -23,7 +23,7 @@
 #ifndef ____tetra_bsaw1__
 #define ____tetra_bsaw1__
 
-long ARG_randomseed;
+extern long ARG_randomseed;
 
 void tetra_bsaw1 (int (**poly_ptr), const int (move_ptr)[2][4][3], const int (saw_ptr)[4][3], unsigned int numberofbeads, int blength_var, int numbricks_var, int (***bricks_ptr), unsigned long *tries);
 

--- a/include/tetra_bsaw2.h
+++ b/include/tetra_bsaw2.h
@@ -23,7 +23,7 @@
 #ifndef ____tetra_bsaw2__
 #define ____tetra_bsaw2__
 
-long ARG_randomseed;
+extern long ARG_randomseed;
 
 void tetra_bsaw2 (int (**poly_ptr), const int (move_ptr)[2][4][3], const int (saw_ptr)[4][3], unsigned int numberofbeads, int blength_var, int numbricks_var, int (***bricks_ptr), unsigned long *tries);
 

--- a/include/tetra_bsaw3.h
+++ b/include/tetra_bsaw3.h
@@ -23,7 +23,7 @@
 #ifndef ____tetra_bsaw3__
 #define ____tetra_bsaw3__
 
-long ARG_randomseed;
+extern long ARG_randomseed;
 
 void tetra_bsaw3 (int (**poly_ptr), const int (move_ptr)[2][4][3], const int (saw_ptr)[4][3], unsigned int numberofbeads, int blength_var, int numbricks_var, int (***bricks_ptr), unsigned long *tries);
 

--- a/include/tetra_fbsaw1.h
+++ b/include/tetra_fbsaw1.h
@@ -23,7 +23,7 @@
 #ifndef ____tetra_fbsaw1__
 #define ____tetra_fbsaw1__
 
-long ARG_randomseed;
+extern long ARG_randomseed;
 
 void tetra_fb_saw1 (int (**poly_ptr), const int (move_ptr)[2][4][3], const int (saw_ptr)[4][3], unsigned int numberofbeads, int blength_var, int numbricks_var, int (***bricks_ptr), int flength, unsigned long *tries);
 

--- a/include/tetra_fbsaw2.h
+++ b/include/tetra_fbsaw2.h
@@ -23,7 +23,7 @@
 #ifndef ____tetra_fbsaw2__
 #define ____tetra_fbsaw2__
 
-long ARG_randomseed;
+extern long ARG_randomseed;
 
 void tetra_fb_saw2 (int (**poly_ptr), const int (move_ptr)[2][4][3], const int (saw_ptr)[4][3], unsigned int numberofbeads, int blength_var, int numbricks_var, int (***bricks_ptr), int flength, unsigned long *tries);
 

--- a/include/tetra_fbsaw3.h
+++ b/include/tetra_fbsaw3.h
@@ -23,7 +23,7 @@
 #ifndef ____tetra_fbsaw3__
 #define ____tetra_fbsaw3__
 
-long ARG_randomseed;
+extern long ARG_randomseed;
 
 void tetra_fb_saw3 (int (**poly_ptr), const int (move_ptr)[2][4][3], const int (saw_ptr)[4][3], unsigned int numberofbeads, int blength_var, int numbricks_var, int (***bricks_ptr), int flength, unsigned long *tries);
 

--- a/include/tetra_fsaw1.h
+++ b/include/tetra_fsaw1.h
@@ -23,7 +23,7 @@
 #ifndef ____tetra_fsaw1__
 #define ____tetra_fsaw1__
 
-long ARG_randomseed;
+extern long ARG_randomseed;
 
 void tetra_fsaw1 (int (**poly_ptr), const int (move_ptr)[2][4][3], const int (saw_ptr)[4][3], unsigned int numberofbeads, int flength, unsigned long *tries);
 

--- a/include/tetra_fsaw2.h
+++ b/include/tetra_fsaw2.h
@@ -23,7 +23,7 @@
 #ifndef ____tetra_fsaw2__
 #define ____tetra_fsaw2__
 
-long ARG_randomseed;
+extern long ARG_randomseed;
 
 void tetra_fsaw2 (int (**poly_ptr), const int (move_ptr)[2][4][3], const int (saw_ptr)[4][3], unsigned int numberofbeads, int flength, unsigned long *tries);
 

--- a/include/tetra_fsaw3.h
+++ b/include/tetra_fsaw3.h
@@ -23,7 +23,7 @@
 #ifndef ____tetra_fsaw3__
 #define ____tetra_fsaw3__
 
-long ARG_randomseed;
+extern long ARG_randomseed;
 
 void tetra_fsaw3 (int (**poly_ptr), const int (move_ptr)[2][4][3], const int (saw_ptr)[4][3], unsigned int numberofbeads, int flength, unsigned long *tries);
 

--- a/include/tetra_fww.h
+++ b/include/tetra_fww.h
@@ -23,7 +23,7 @@
 #ifndef ____tetra_fww__
 #define ____tetra_fww__
 
-long ARG_randomseed;
+extern long ARG_randomseed;
 
 void tetra_fww (int (**poly_ptr), const int (move_ptr)[2][4][3], const int (saw_ptr)[4][3], unsigned int numberofbeads);
 

--- a/include/tetra_rw.h
+++ b/include/tetra_rw.h
@@ -23,7 +23,7 @@
 #ifndef ____tetra_rw__
 #define ____tetra_rw__
 
-long ARG_randomseed;
+extern long ARG_randomseed;
 
 void tetra_rw (int (**poly_ptr), const int (move_ptr)[2][4][3], unsigned int numberofbeads);
 

--- a/include/tetra_saw1.h
+++ b/include/tetra_saw1.h
@@ -23,7 +23,7 @@
 #ifndef ____tetra_saw1__
 #define ____tetra_saw1__
 
-long ARG_randomseed;
+extern long ARG_randomseed;
 
 void tetra_saw1 (int (**poly_ptr), const int (move_ptr)[2][4][3], const int (saw_ptr)[4][3], unsigned int numberofbeads, unsigned long *tries);
 

--- a/include/tetra_saw2.h
+++ b/include/tetra_saw2.h
@@ -23,7 +23,7 @@
 #ifndef ____tetra_saw2__
 #define ____tetra_saw2__
 
-long ARG_randomseed;
+extern long ARG_randomseed;
 
 void tetra_saw2 (int (**poly_ptr), const int (move_ptr)[2][4][3], const int (saw_ptr)[4][3], unsigned int numberofbeads, unsigned long *tries);
 

--- a/include/tetra_saw3.h
+++ b/include/tetra_saw3.h
@@ -23,7 +23,7 @@
 #ifndef ____tetra_saw3__
 #define ____tetra_saw3__
 
-long ARG_randomseed;
+extern long ARG_randomseed;
 
 void tetra_saw3 (int (**poly_ptr), const int (move_ptr)[2][4][3],  const int (saw_ptr)[4][3], unsigned int numberofbeads, unsigned long *tries);
 

--- a/src/main.c
+++ b/src/main.c
@@ -116,59 +116,59 @@ double pi;
 
 
 int main(int argc, char **argv) {
-    
-    /* the times recorded are: 
+
+    /* the times recorded are:
      start of programm, start of chain generation,
      end of chain generation, end of programm */
     double time[4];
     time[0] = time_of_day();
-    
-    
+
+
     //-----------------------------------------------------------------------------------------------------------------------------------------------
     //-----------------------------------------------------------------------------------------------------------------------------------------------
     // open all neccessary files
-    
+
     // general output file, contains basically everything which was written to the terminal
     FILE * output_file;
     output_file = fopen("output_file.dat", "w+");
-    
+
     FILE * conv_obs_file;
     conv_obs_file = fopen("convergence_obs.dat", "w+");
-    
+
     // pair correlation function can be weighted with potentials
     FILE * pair_correl_file;
     pair_correl_file = fopen("pair_correlation_function.dat", "w+");
-    
+
     //------------------------------------------------------------------------------
     // all files connected to intramolecular interactions
 
     FILE * intra_pot_file;
     intra_pot_file = fopen("intramolecular_obs.dat", "w+");
-    
+
     FILE * intra_boltzman_factors_hist;
     intra_boltzman_factors_hist = fopen("intramolecular_factors_hist.dat", "w+");
-    
+
     FILE * intra_interactions_file;
     intra_interactions_file = fopen("intramolecular_interactions_hist.dat", "w+");
-    
+
  //   FILE * intra_interactions_testfile;
  //   intra_interactions_testfile = fopen("intramolecular_interactions_testhist.dat", "w+");
-    
+
     FILE * convergence_intraweights;
     convergence_intraweights = fopen("intramolecular_convergence_Z.dat", "w+");
     fprintf(convergence_intraweights, "### convergence_point -- sum-of-boltzman-factors \n");
-    
+
     FILE * conv_intraobs_file;
     conv_intraobs_file = fopen("intramolecular_convergence_obs.dat", "w+");
 
-    
+
     //-----------------------------------------------------------------------------------------------------------------------------------------------
     //-----------------------------------------------------------------------------------------------------------------------------------------------
     // input and first output
-    
-    
+
+
     // hello message of the programm, always displayed!
-    
+
     log_out(output_file, "\n-----------------------------------------------------------------------------------\n");
     log_out(output_file, "Roulattice version 1.1, Copyright (C) 2015 Johannes Dietschreit\n");
     log_out(output_file, "This program comes with ABSOLUTELY NO WARRANTY; for version details type '-info'.\n");
@@ -180,17 +180,17 @@ int main(int argc, char **argv) {
     log_out(output_file, "\t\tModels for Self-Avoiding Polymer Chains on the Tetrahedral Lattice.\n");
     log_out(output_file, "\t\tMacromol. Theory Simul. 2014, 23, 452-463\n");
     log_out(output_file, "-----------------------------------------------------------------------------------\n");
-    
-    
-    
+
+
+
     /* get the arguments from the comand line */
     getArgs(output_file, argc, argv);
-    
-    
+
+
     //------------------------------------------------------------------------------------
     // for reading DCD-files
     // this has to be early in the code, because it sets the variables ARG_numberofbeads and ARG_numberofframes!
-    
+
     // variables concerning reading dcd
     molfile_timestep_t timestep;
     void *v;
@@ -205,38 +205,38 @@ int main(int argc, char **argv) {
             fprintf(stderr, "ERROR: open_dcd_read failed for file %s\n", dcdFileName);
             return EXIT_FAILURE;
         }
-        
+
         dcd = (dcdhandle *)v;
         sizeMB = ((natoms * 3.0) * dcd->nsets * 4.0) / (1024.0 * 1024.0);
         totalMB += sizeMB;
-        
+
         log_out(output_file, "Read DCD: %d atoms, %d frames, size: %6.1fMB\n", natoms, dcd->nsets, sizeMB);
-        
+
         timestep.coords = (float *)malloc(3*sizeof(float)*natoms);
-        
+
         ARG_numberofbeads=dcd->natoms;
         ARG_numberofframes=dcd->nsets;
     }
     //------------------------------------------------------------------------------------
-    
+
 
     // print all the options to the screen so one can check whether the right thing gets computed
     print_set_options(output_file, ARG_typeofrun, ARG_flength, ARG_fflength, ARG_blength, ARG_numberofbeads, ARG_numberofframes, ARG_randomseed, ARG_bondlength, ARG_torsion, ARG_intra_potential, ARG_intra_parameter1, ARG_intra_parameter2);
-    
-    
-    
+
+
+
     //-----------------------------------------------------------------------------------------------------------------------------------------------
     //-----------------------------------------------------------------------------------------------------------------------------------------------
     // physical constants
-    
+
     pi = acos(-1.0);
-    
+
     //-----------------------------------------------------------------------------------------------------------------------------------------------
     //-----------------------------------------------------------------------------------------------------------------------------------------------
-    
-    
+
+
     /* Initialize the most important variables */
-    
+
     // stuff with bond lengths
     const double inv_sqrt3 = 1.0/sqrt(3.0);
     const double bondlength = ARG_bondlength;
@@ -247,24 +247,24 @@ int main(int argc, char **argv) {
     else {// this is for runs on simple cubic lattice
         recast_factor = bondlength;
     }
-    
+
     // variables with atom numbers etc
     const int last_atom = ARG_numberofbeads -1;
     const unsigned int number_of_torsions = ARG_numberofbeads -3;
     // number of frag, fragfags, endfrags, fragbricks, endbricks
     unsigned int numof_frags_bricks[5] = {0};
-    
-    
+
+
     // fractions of the number of frames
     const unsigned long permill_frames = ARG_numberofframes / 1000; // used for convergence
     const unsigned long percent_frames = ARG_numberofframes / 100; // used for ramining time
     const unsigned long tenth_frames = ARG_numberofframes / 10; // used for error estimation
     int cent;
     int tenth;
-    
+
     int counter; // counter which can be used at any parts of the main programm, should only be used locally in a loop
-    
-    
+
+
     // basic moves on the tetrahedral lattice, back and forth
     const int move[2][4][3] = {
         {
@@ -280,7 +280,7 @@ int main(int argc, char **argv) {
             {1, -1, -1}
         }
     };
-    
+
     // moves possible in SAW (no walking back)
     const int sawmoves[4][3] = {
         {1, 2, 3},
@@ -288,60 +288,60 @@ int main(int argc, char **argv) {
         {0, 1, 3},
         {0, 1, 2}
     };
-    
-    
+
+
     //-----------------------------------------------------------------------
     // building bricks are used to put parts together which are pre-checked
     int ***building_bricks=NULL;
-    
+
     int numberofbricks;
-    
+
     if (ARG_typeofrun==13 || ARG_typeofrun==14 || ARG_typeofrun==23 || ARG_typeofrun==24 || ARG_typeofrun==33 || ARG_typeofrun==34){
-        
+
         // thise generates the bricks
         building_bricks = make_bricks_saw(building_bricks, move, sawmoves, ARG_blength, &numberofbricks, ARG_strictness);
         if (NULL==building_bricks[0][0]){
             return EXIT_FAILURE;
         }
-        
+
         log_out(output_file, "%d bricks were generated, with a length of %d \n", numberofbricks, ARG_blength);
-        
+
     }
-    
-    
-    
+
+
+
     //----------------------------------------------------------------------------------------------------------------------------------------------------------
     //----------------------------------------------------------------------------------------------------------------------------------------------------------
-    
+
     /* Initialize beads vector and set all values to zero */
     int **int_polymer;
     int_polymer = calloc(ARG_numberofbeads, sizeof(int *));
-    
+
     double **double_polymer;
     double_polymer = calloc(ARG_numberofbeads, sizeof(double *));
-    
+
     for (int dim1=0; dim1<ARG_numberofbeads;dim1++){
-        
+
         int_polymer[dim1] = calloc(3, sizeof(int *));
         double_polymer[dim1] = calloc(3, sizeof(double *));
-        
+
     }
-    
-    
+
+
     //----------------------------------------------------------------------------------------------------------------------------------------------------------
     //----------------------------------------------------------------------------------------------------------------------------------------------------------
     // observables
-    
+
     OBSERVABLE normal_obs;
-    
+
     normal_obs.maxee = 0.0; // maximal stretch of polymer
-    
+
     OBSERVABLE intra_obs[100];
 
     //-------------------------------------------------------
     // initialization of all the OBSERVABLE variables
     //-------------------------------------------------------
-    
+
     normal_obs.err_ee2 = (double *) calloc(11, sizeof(double));
     if(NULL == normal_obs.err_ee2) {
         fprintf(stderr, "Allocation of ee2 variable failed! \n");
@@ -352,7 +352,7 @@ int main(int argc, char **argv) {
         fprintf(stderr, "Allocation of rgyr variable failed! \n");
         return EXIT_FAILURE;
     }
-    
+
     if (ARG_intra_potential>0) {
         for (int dim1=0; dim1<100; dim1++) {
             intra_obs[dim1].err_ee2 =(double *) calloc(11, sizeof(double));
@@ -363,8 +363,8 @@ int main(int argc, char **argv) {
             }
         }
     }
-    
-    
+
+
     // initializes the observables for torsional analysis (optional)
     if (ARG_torsion==1) {
         normal_obs.err_pt = (double *) calloc(11, sizeof(double));
@@ -372,7 +372,7 @@ int main(int argc, char **argv) {
             fprintf(stderr, "Allocation of torsion variable failed! \n");
             return EXIT_FAILURE;
         }
-        
+
         if (ARG_intra_potential>0) {
             for (int dim1=0; dim1<100; dim1++) {
                 intra_obs[dim1].pt = 0.0;
@@ -384,7 +384,7 @@ int main(int argc, char **argv) {
             }
         }
     }
-    
+
     // initializes the observables for loss of solven accessible surface area analysis (optional)
     if (ARG_sasa==1){
         normal_obs.err_dsasa = (double *) calloc(11, sizeof(double));
@@ -392,7 +392,7 @@ int main(int argc, char **argv) {
             fprintf(stderr, "Allocation of D-SASA variable failed! \n");
             return EXIT_FAILURE;
         }
-        
+
         if (ARG_intra_potential>0) {
             for (int dim1=0; dim1<100; dim1++) {
                 intra_obs[dim1].dsasa = 0.0;
@@ -404,7 +404,7 @@ int main(int argc, char **argv) {
             }
         }
     }
-    
+
     // this is needed for the pair correlation function
     double *pair_correlation_obs;
     if (ARG_pair_correlation==1) {
@@ -413,13 +413,13 @@ int main(int argc, char **argv) {
             fprintf(stderr, "Allocation of pair_correlation_obs failed! \n");
             return EXIT_FAILURE;
         }
-        
+
         normal_obs.pair_corr = (double *) calloc(2*ARG_numberofbeads, sizeof(double));
         if(NULL == normal_obs.pair_corr) {
             fprintf(stderr, "Allocation of pair_corr failed! \n");
             return EXIT_FAILURE;
         }
-        
+
         if (ARG_intra_potential>0) {
             for (int dim1=0; dim1<100; dim1++) {
                 intra_obs[dim1].pair_corr = (double *) calloc(2*ARG_numberofbeads, sizeof(double));
@@ -431,21 +431,21 @@ int main(int argc, char **argv) {
         }
     }
     //-------------------------
-    
-    
+
+
     // this will provide a measure for entropy loss calculation
     unsigned long *attempts_successes;
     double *log_attempts;
     log_attempts = (double*) calloc(11, sizeof(double));
-    
+
     // set the number of entries in this list, it depends on the typeofrun, but not the saw-type
     // last entry is the recast number of attempts which provides a measure for the entropy loss
-    
+
     //-------------------------------------------------------------------------------------------
     //-------------------------------------------------------------------------------------------
     // calculate variables which depend on the typeofrun
-    
-    
+
+
     switch (ARG_typeofrun) {
             // normal SAWX
         case 10:
@@ -476,17 +476,17 @@ int main(int argc, char **argv) {
             numof_frags_bricks[3] = ARG_flength/ARG_blength;
             numof_frags_bricks[4] = (ARG_numberofbeads-1-ARG_flength*numof_frags_bricks[3])/ARG_blength;
             break;
-            
+
         default:
             break;
     }
-    
-    
+
+
     //----------------------------------------------------------------------------------------------------------------------------------------------------------
     //----------------------------------------------------------------------------------------------------------------------------------------------------------
     // intra molecular interactions
-    
-    
+
+
     // boltzman-factors, the intramolecular energy, the enrgy time the boltzmanfactor (entropy)
     double *intra_boltzman_factors;
     double *intra_highest_boltzmanfactor;
@@ -495,24 +495,21 @@ int main(int argc, char **argv) {
     double **intra_sum_of_enrgyboltz;
     int *intra_interactions_hist;
  //   double *intra_interactions_testhist;
-    
-    double intra_max_factor = 0.0;
-    double intra_min_factor = 0.0;
-    
+
     // binning the energies of the intra-factors
     double intra_binmin;
     double intra_binmax;
     double intra_binwidth;
     int **intra_energybin;
-    
-    
-    
+
+
+
     // these will be the parameter of the intra molecular force
     double *intra_parameter1;
     double *intra_parameter2;
-    
-    
-    
+
+
+
     if (ARG_intra_potential > 0){
         switch (ARG_intra_potential) {
                 // 1-10 potential well + torsional potential, given energy values
@@ -524,7 +521,7 @@ int main(int argc, char **argv) {
                 intra_sum_of_enrgyboltz = (double**) calloc(1, sizeof(double*));
                 intra_sum_of_boltzfactors[0] = (double*) calloc(10, sizeof(double));
                 intra_sum_of_enrgyboltz[0]  = (double*) calloc(10, sizeof(double));
-                
+
                 intra_parameter1 = (double*) malloc(1 * sizeof(double));
                 intra_parameter2 = (double*) malloc(1 * sizeof(double));
                 intra_interactions_hist = calloc(ARG_numberofbeads, sizeof(int));
@@ -537,7 +534,7 @@ int main(int argc, char **argv) {
                 intra_energybin = (int**) calloc(1, sizeof(int *));
                 intra_energybin[0] = (int*) calloc(((intra_binmax-intra_binmin)/intra_binwidth), sizeof(int));
                 break;
-                
+
                 // 1-10 potential well + torsional potential, given energy value range! 10x10
             case 2:
                 intra_boltzman_factors = (double*) calloc(100, sizeof(double));
@@ -545,12 +542,12 @@ int main(int argc, char **argv) {
                 intra_energy = (double*) calloc(100, sizeof(double));
                 intra_sum_of_boltzfactors = (double**) calloc(100, sizeof(double));
                 intra_sum_of_enrgyboltz = (double**) calloc(100, sizeof(double*));
-                
+
                 for (int dim1=0; dim1<100; ++dim1) {
                     intra_sum_of_boltzfactors[dim1] = (double*) calloc(10, sizeof(double));
                     intra_sum_of_enrgyboltz[dim1]  = (double*) calloc(10, sizeof(double));
                 }
-                
+
                 intra_parameter1 = (double*) malloc(10 * sizeof(double));
                 intra_parameter2 = (double*) malloc(10 * sizeof(double));
                 intra_interactions_hist = calloc(ARG_numberofbeads, sizeof(int));
@@ -567,7 +564,7 @@ int main(int argc, char **argv) {
                     intra_energybin[dim1] = (int*) calloc(((intra_binmax-intra_binmin)/intra_binwidth), sizeof(int));
                 }
                 break;
-                
+
             default:
                 fprintf(stderr, "This intramolecular potential doesn't exist! \n");
                 break;
@@ -575,68 +572,68 @@ int main(int argc, char **argv) {
 
     }
 
-    
-    
+
+
 //----------------------------------------------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    
-    
-    
-    
+
+
+
+
     /* start of chain generation*/
     time[1] = time_of_day();
-    
+
     for (unsigned long frame=0; frame<ARG_numberofframes; frame++){
-        
+
         tenth = frame/tenth_frames;
-        
+
         switch(ARG_typeofrun){
-                
+
             case 0:
                 dcd_to_polymer(double_polymer, v, natoms, &timestep, dcd, frame, ARG_numberofbeads);
                 break;
-                
+
             case 1:
                 tetra_rw(int_polymer, move, ARG_numberofbeads);
                 break;
-                
+
             case 2:
                 tetra_fww(int_polymer, move, sawmoves, ARG_numberofbeads);
                 break;
-                
+
             case 10:
                 tetra_saw1(int_polymer, move, sawmoves, ARG_numberofbeads, attempts_successes);
                 break;
-                
+
             case 11:
                 tetra_fsaw1(int_polymer, move, sawmoves, ARG_numberofbeads, ARG_flength, attempts_successes);
                 break;
-                
+
             case 13:
                 tetra_bsaw1(int_polymer, move, sawmoves, ARG_numberofbeads, ARG_blength, numberofbricks, building_bricks, attempts_successes);
                 break;
-                
+
    //         case 14: // here is something awfully wrong, can't find the mistake at the moment!
    //             tetra_fb_saw1(int_polymer, move, sawmoves, ARG_numberofbeads, ARG_blength, numberofbricks, building_bricks, ARG_flength, attempts_successes);
    //             break;
-                
+
             case 20:
                 tetra_saw2(int_polymer, move, sawmoves, ARG_numberofbeads, attempts_successes);
                 break;
-                
+
             case 21:
                 tetra_fsaw2(int_polymer, move, sawmoves, ARG_numberofbeads, ARG_flength, attempts_successes);
                 break;
-                
+
             case 23:
                 tetra_bsaw2(int_polymer, move, sawmoves, ARG_numberofbeads, ARG_blength, numberofbricks, building_bricks, attempts_successes);
                 break;
-                
+
             case 24:
                 tetra_fb_saw2(int_polymer, move, sawmoves, ARG_numberofbeads, ARG_blength, numberofbricks, building_bricks, ARG_flength, attempts_successes);
                 break;
-                
+
             case 30:
                 tetra_saw3(int_polymer, move, sawmoves, ARG_numberofbeads, attempts_successes);
                 break;
@@ -644,33 +641,33 @@ int main(int argc, char **argv) {
             case 31:
                 tetra_fsaw3(int_polymer, move, sawmoves, ARG_numberofbeads, ARG_flength, attempts_successes);
                 break;
-                
+
             case 33:
                 tetra_bsaw3(int_polymer, move, sawmoves, ARG_numberofbeads, ARG_blength, numberofbricks, building_bricks, attempts_successes);
                 break;
-                
+
             case 34:
                 tetra_fb_saw3(int_polymer, move, sawmoves, ARG_numberofbeads, ARG_blength, numberofbricks, building_bricks, ARG_flength, attempts_successes);
                 break;
 
-                
+
             default:
                 log_out(output_file, "ERROR: ARG_typeofrun = %d isn't recognized by the main part of the programm!\n", ARG_typeofrun);
                 usage_error();
-                
+
         } // end of chain generaiton
-        
-        
+
+
         // copies the lattice polymer into an array with doubles so that the chosen bond length can be used.
         if (ARG_typeofrun>0) {
             recast(double_polymer, int_polymer, ARG_numberofbeads, &recast_factor);
         }
-        
-        
+
+
         //-----------------------------------------------------------------------------
         //-----------------------------------------------------------------------------
         // get most important observables
-        
+
         // end-to-end distance^2
         normal_obs.ee2 = double_distance2(double_polymer[last_atom], double_polymer[0]);
         normal_obs.err_ee2[tenth] += normal_obs.ee2;
@@ -695,34 +692,34 @@ int main(int argc, char **argv) {
                 normal_obs.pair_corr[pairs] += pair_correlation_obs[pairs];
             }
         }
-        
-        
-        
 
-        
-        
-        
-        
-        
+
+
+
+
+
+
+
+
         //-----------------------------------------------------------------------------
         //-----------------------------------------------------------------------------
         // calculate boltzman factors if intramolecular forces are switched on
-        
+
         switch (ARG_intra_potential) {
-                
+
             // torsion + square well potential
             case 1:
                 intrapot_torsion_well(intra_boltzman_factors, intra_energy, intra_interactions_hist, intra_highest_boltzmanfactor, intra_parameter1, intra_parameter2, normal_obs.pt, number_of_torsions, int_polymer, ARG_numberofbeads);
-                
+
                 intra_sum_of_enrgyboltz[0][tenth] += (intra_boltzman_factors[0]*intra_energy[0]);
                 intra_sum_of_boltzfactors[0][tenth] += intra_boltzman_factors[0];
-                
+
                 intra_obs[0].err_ee2[tenth] += normal_obs.ee2 * intra_boltzman_factors[0];
                 intra_obs[0].err_rgyr[tenth] += normal_obs.rgyr * intra_boltzman_factors[0];
                 intra_obs[0].err_pt[tenth] += normal_obs.pt * intra_boltzman_factors[0];
-                
+
                 intra_binenergy(intra_energy[0], intra_binmin, intra_binwidth, intra_energybin[0]);
-                
+
                 // pair correlation function
                 if (ARG_pair_correlation==1){
                     for (int pairs=0; pairs<(2*ARG_numberofbeads); pairs++) {
@@ -730,12 +727,12 @@ int main(int argc, char **argv) {
                     }
                 }
                 break;
-                
+
             // torsion + square well potential, range of energy values
             case 2:
                 intrapot_torsion_well_scan(intra_boltzman_factors, intra_energy, intra_interactions_hist, intra_highest_boltzmanfactor, intra_parameter1, intra_parameter2, normal_obs.pt, number_of_torsions, int_polymer, ARG_numberofbeads);
                 //intrapot_torsion_well_test(intra_boltzman_factors, intra_energy, intra_interactions_hist, intra_interactions_testhist,intra_highest_boltzmanfactor, intra_parameter1, intra_parameter2, normal_obs.pt, number_of_torsions, int_polymer, ARG_numberofbeads);
-                
+
                 for (int dim1=0; dim1<100; ++dim1) {
                     intra_sum_of_enrgyboltz[dim1][tenth] += (intra_boltzman_factors[dim1]*intra_energy[dim1]);
                     intra_sum_of_boltzfactors[dim1][tenth] += intra_boltzman_factors[dim1];
@@ -750,86 +747,86 @@ int main(int argc, char **argv) {
                         }
                     }
                 }
-                
+
                 break;
-                
+
             default:
                 break;
-                
+
         }// boltzman factors and energies have been determined
             // end of anything related to intramolecular potentials
-        
-        
-        
+
+
+
         //--------------------------------------------------------------------------------------------
         //--------------------------------------------------------------------------------------------
         // everything has been calculated, now is the opportunity to look at convergence
-        
+
         if ((frame+1)%permill_frames==0) {
             // convergence of variables with equal weights
             convergence(&normal_obs, (double)number_of_torsions, (frame+1), conv_obs_file);
-            
-            
+
+
             switch (ARG_intra_potential) {
-                    
+
                 case 1:
                     weighted_convergence(intra_obs, 1,intra_sum_of_boltzfactors, (double)number_of_torsions, (frame+1), conv_intraobs_file);
                     weights_growth(intra_sum_of_boltzfactors, 1, (frame+1), convergence_intraweights);
                     break;
-                    
+
                     // convergence of weighted ensemble
                 case 2:
                     weighted_convergence(intra_obs, 100, intra_sum_of_boltzfactors, (double)number_of_torsions, (frame+1), conv_intraobs_file);
                     weights_growth(intra_sum_of_boltzfactors, 100, (frame+1), convergence_intraweights);
                     break;
-                    
+
                 default:
                     break;
             }
-            
-            
+
+
             if ((frame+1)%percent_frames==0) {
-                
+
                 cent = (frame+1)/percent_frames;
-                
+
                 log_out(output_file, "Finished %i%%\t...remaining time: %f seconds \n", (cent), ((time_of_day()-time[1])*(100-cent)/(cent)));
-                
+
                 if ((frame+1)%tenth_frames==0) {
                     // every bin after the first will also include the attempts in the previous bin!
                     log_attempts[tenth] = recalc_attempts(attempts_successes, numof_frags_bricks, numberofbricks, ARG_typeofrun);
                 }
-                
-                
+
+
             }
         }
-        
-    } // end of loop over number of frames
-    
-    
-    
 
-    
-    
+    } // end of loop over number of frames
+
+
+
+
+
+
     //----------------------------------------------------------------------------------------------------------------------------------------------------------
     //----------------------------------------------------------------------------------------------------------------------------------------------------------
-    
+
     /* Post-Process */
     time[2] = time_of_day();
-    
+
     // Maybe there should be a function, which returns means and errors; it calls these subroutines ....
-    
+
     log_attempts[10] = recalc_attempts(attempts_successes, numof_frags_bricks, numberofbricks, ARG_typeofrun);
     for (int dim1=9; dim1>0; --dim1) {
         log_attempts[dim1] = log( exp(log_attempts[dim1]) - exp(log_attempts[dim1-1]) );
     }
-    
+
     // get means and errors
     normal_obs.ee2 = sqrt( average(normal_obs.err_ee2, ARG_numberofframes) );
     normal_obs.err_ee2[10] = error_sq_ten(normal_obs.ee2, normal_obs.err_ee2, ARG_numberofframes);
     normal_obs.rgyr = sqrt( average(normal_obs.err_rgyr, ARG_numberofframes) );
     normal_obs.err_rgyr[10] = error_sq_ten(normal_obs.rgyr, normal_obs.err_rgyr, ARG_numberofframes);
     normal_obs.S = (log((double)ARG_numberofframes) - log_attempts[10]);
-    
+
     if (ARG_torsion==1) {
         normal_obs.pt = average(normal_obs.err_pt, ARG_numberofframes);
         normal_obs.err_pt[10] = error_ten(normal_obs.pt, normal_obs.err_pt, ARG_numberofframes);
@@ -838,24 +835,24 @@ int main(int argc, char **argv) {
         normal_obs.dsasa = average(normal_obs.err_dsasa, ARG_numberofframes);
         normal_obs.err_dsasa[10] = error_ten(normal_obs.dsasa, normal_obs.err_dsasa, ARG_numberofframes);
     }
-    
-    
-    
+
+
+
     //----------------------------------------------------------------------------------------------------------------------------------------------------------
     //----------------------------------------------------------------------------------------------------------------------------------------------------------
-    
+
     /* Output */
     time[3] = time_of_day();
-    
+
     // print the output to screen and to the output_file
-    
+
     log_out(output_file, "\n-----------------------------------------------------------------------------------\n");
     log_out(output_file, "FINAL OUTPUT\n");
-    
+
     log_out(output_file, "\nEntropic Considerations:\n");
     log_out(output_file, "Attempts to Compute the Ensemble: %e  \n", exp(log_attempts[10]));
     log_out(output_file, "\tDelta S / k_B (FWW -> SAWn): %f \n",  normal_obs.S);
-    
+
     log_out(output_file, "\nChosen Observables:\n");
     log_out(output_file, "Flory Radius: %f +- %f \n", normal_obs.ee2, normal_obs.err_ee2[10]);
     log_out(output_file, "Radius of Gyration: %f +- %f \n", normal_obs.rgyr, normal_obs.err_rgyr[10]);
@@ -872,8 +869,8 @@ int main(int argc, char **argv) {
 
     log_out(output_file, "\nThis ouput is also written to 'output_file.dat'.\n");
     log_out(output_file, "The convergence was written to 'convergence_obs.dat'.\n");
-    
-    
+
+
     if (ARG_intra_potential>0) {
         log_out(output_file, "\nThe Boltzmann-weighted observables can be found in 'intramolecular_obs.dat'.\n");
         log_out(output_file, "The Boltzmann-weighted convergence was written to 'intramolecular_convergence_obs.dat'.\n");
@@ -881,17 +878,17 @@ int main(int argc, char **argv) {
         log_out(output_file, "The sum of the Boltzmann-factors was written to 'intramolecular_convergence_Z.dat'.\n");
         log_out(output_file, "A histogram of the intramolecular contacts was written to 'intramolecular_interactions_hist.dat'.\n");
     }
-    
-    
+
+
 
     //----------------------------------------------------------------------------------------------------------------------------------------------------------
     //----------------------------------------------------------------------------------------------------------------------------------------------------------
-    
+
     /* Output to file */
-    
+
     // pair correlation function
     if (ARG_pair_correlation==1){
-        
+
         if (ARG_intra_potential==0) {
             fprintf(pair_correl_file,"# r_0-r_1 pair_correlation \n");
             for (int dim1=0; dim1<(2*ARG_numberofbeads); dim1++){
@@ -904,88 +901,88 @@ int main(int argc, char **argv) {
                 fprintf(pair_correl_file, "%i %e %e \n", dim1, (normal_obs.pair_corr[dim1]/(double)ARG_numberofframes), (intra_obs[46].pair_corr[dim1]/average(intra_sum_of_boltzfactors[46], 1)));
             }
         }
-        
-        
+
+
     }
-    
-    
-    
+
+
+
     switch (ARG_intra_potential) {
-            
+
         case 1:
             // prints the weighted observables to file with error estimate
             fprintf(intra_pot_file, "### 1-9 well, torsion eps, Rf, Rf_err, Rg, Rg_err, pT, pT_err, DS, DS_err, <exp(-E/kT)>/exp(-Emax/kT) \n" );
 
             intra_obs[0].ee2 = sqrt(weighted_average(intra_obs[0].err_ee2, intra_sum_of_boltzfactors[0]));
             intra_obs[0].err_ee2[10] = weighted_error_sq_ten(intra_obs[0].ee2, intra_obs[0].err_ee2, intra_sum_of_boltzfactors[0]);
-            
+
             intra_obs[0].rgyr = sqrt(weighted_average(intra_obs[0].err_rgyr, intra_sum_of_boltzfactors[0]));
             intra_obs[0].err_rgyr[10] = weighted_error_sq_ten(intra_obs[0].rgyr, intra_obs[0].err_rgyr, intra_sum_of_boltzfactors[0]);
-            
+
             intra_obs[0].pt = weighted_average(intra_obs[0].err_pt, intra_sum_of_boltzfactors[0]);
             intra_obs[0].err_pt[10] = weighted_error_ten(intra_obs[0].pt, intra_obs[0].err_pt, intra_sum_of_boltzfactors[0]);
-            
+
             intra_obs[0].S = intra_entropy(intra_sum_of_boltzfactors[0], intra_sum_of_enrgyboltz[0], log_attempts[10]);
             intra_obs[0].err_S = intra_entropy_error_ten(intra_obs[0].S, intra_sum_of_boltzfactors[0], intra_sum_of_enrgyboltz[0], log_attempts);
-            
+
             fprintf(intra_pot_file, "%f %f %e %e %e %e %e %e %e %e %e \n", intra_parameter1[0], intra_parameter2[0], intra_obs[0].ee2, intra_obs[0].err_ee2[10], intra_obs[0].rgyr, intra_obs[0].err_rgyr[10], (intra_obs[0].pt/(double)number_of_torsions), (intra_obs[0].err_pt[10]/(double)number_of_torsions), intra_obs[0].S, intra_obs[0].err_S, intra_loss_of_conf(intra_sum_of_boltzfactors[0], intra_highest_boltzmanfactor[0], ARG_numberofframes));
 
-            
+
             // histogram over 1-9 interacitons
             fprintf(intra_interactions_file, "# number-of-nn-interactions, occurence \n");
             for (int dim1=0; dim1<ARG_numberofbeads; ++dim1) {
                 fprintf(intra_interactions_file, "%i %i \n", dim1, intra_interactions_hist[dim1]);
             }
-            
+
             // test histogram
             //      fprintf(intra_interactions_testfile, "# sperating-bonds 0_contacts 1_contacts 2_contacts\n");
             //      for (int dim1=0; dim1<98; dim1+=3) {
             //          fprintf(intra_interactions_testfile, "%i %e %e %e \n", (dim1/3+4), intra_interactions_testhist[dim1]/average(intra_sum_of_boltzfactors[46], 1), intra_interactions_testhist[dim1+1]/average(intra_sum_of_boltzfactors[46], 1), intra_interactions_testhist[dim1+2]/average(intra_sum_of_boltzfactors[46], 1));
             //     }
-            
+
             // histogram of intra energies
             fprintf(intra_boltzman_factors_hist, "# energy, bincount-for-these-parameters");
             for (int dim1=0; dim1<((intra_binmax-intra_binmin)/intra_binwidth); ++dim1) {
                 fprintf(intra_boltzman_factors_hist, "%f %i \n", (intra_binmin+(double)dim1*intra_binwidth), intra_energybin[0][dim1]);
             }
             break;
-            
+
         case 2:
             // prints the weighted observables to file with error estimate
             fprintf(intra_pot_file, "### 1-9 well, torsion eps, Rf, Rf_err, Rg, Rg_err, pT, pT_err, DS, DS_err, <exp(-E/kT)>/exp(-Emax/kT) \n" );
             for (int dim1=0; dim1<10; dim1++) {
                 for (int dim2=0; dim2<10; dim2++) {
-                    
+
                     counter = dim1*10 + dim2;
-                    
+
                     intra_obs[counter].ee2 = sqrt(weighted_average(intra_obs[counter].err_ee2, intra_sum_of_boltzfactors[counter]));
                     intra_obs[counter].err_ee2[10] = weighted_error_sq_ten(intra_obs[counter].ee2, intra_obs[counter].err_ee2, intra_sum_of_boltzfactors[counter]);
-                    
+
                     intra_obs[counter].rgyr = sqrt(weighted_average(intra_obs[counter].err_rgyr, intra_sum_of_boltzfactors[counter]));
                     intra_obs[counter].err_rgyr[10] = weighted_error_sq_ten(intra_obs[counter].rgyr, intra_obs[counter].err_rgyr, intra_sum_of_boltzfactors[counter]);
-                    
+
                     intra_obs[counter].pt = weighted_average(intra_obs[counter].err_pt, intra_sum_of_boltzfactors[counter]);
                     intra_obs[counter].err_pt[10] = weighted_error_ten(intra_obs[counter].pt, intra_obs[counter].err_pt, intra_sum_of_boltzfactors[counter]);
-                    
+
                     intra_obs[counter].S = intra_entropy(intra_sum_of_boltzfactors[counter], intra_sum_of_enrgyboltz[counter], log_attempts[10]);
                     intra_obs[counter].err_S = intra_entropy_error_ten(intra_obs[counter].S, intra_sum_of_boltzfactors[counter], intra_sum_of_enrgyboltz[counter], log_attempts);
-                    
+
                     fprintf(intra_pot_file, "%f %f %e %e %e %e %e %e %e %e %e \n", intra_parameter1[dim1], intra_parameter2[dim2], intra_obs[counter].ee2, intra_obs[counter].err_ee2[10], intra_obs[counter].rgyr, intra_obs[counter].err_rgyr[10], (intra_obs[counter].pt/(double)number_of_torsions), (intra_obs[counter].err_pt[10]/(double)number_of_torsions), intra_obs[counter].S, intra_obs[counter].err_S, intra_loss_of_conf(intra_sum_of_boltzfactors[counter], intra_highest_boltzmanfactor[counter], ARG_numberofframes));
                 }
             }
-            
+
             // histogram over 1-9 interacitons
             fprintf(intra_interactions_file, "# number-of-nn-interactions, occurence \n");
             for (int dim1=0; dim1<ARG_numberofbeads; ++dim1) {
                 fprintf(intra_interactions_file, "%i %i \n", dim1, intra_interactions_hist[dim1]);
             }
-            
+
             // test histogram
             //      fprintf(intra_interactions_testfile, "# sperating-bonds 0_contacts 1_contacts 2_contacts\n");
             //      for (int dim1=0; dim1<98; dim1+=3) {
             //          fprintf(intra_interactions_testfile, "%i %e %e %e \n", (dim1/3+4), intra_interactions_testhist[dim1]/average(intra_sum_of_boltzfactors[46], 1), intra_interactions_testhist[dim1+1]/average(intra_sum_of_boltzfactors[46], 1), intra_interactions_testhist[dim1+2]/average(intra_sum_of_boltzfactors[46], 1));
             //     }
-            
+
             // histogram of intra energies
             fprintf(intra_boltzman_factors_hist, "# energy, bincount-for-these-parameters");
             for (int dim1=0; dim1<((intra_binmax-intra_binmin)/intra_binwidth); ++dim1) {
@@ -997,34 +994,34 @@ int main(int argc, char **argv) {
             }
 
             break;
-            
+
         default:
             break;
     }
 
 
-    
-    
-    
-    
+
+
+
+
     log_out(output_file, "\nComputation of Chains:\t%f seconds \nTotal Runtime:\t\t%f seconds \n\n", (time[2]-time[1]), (time[3]-time[0]));
     log_out(output_file, "End of Programm!\n-----------------------------------------------------------------------------------\n");
-    
+
     // make sure everything gets printed
     fflush(stdout);
-    
-    
-    
+
+
+
     //----------------------------------------------------------------------------------------------------------------------------------------------------------
     //----------------------------------------------------------------------------------------------------------------------------------------------------------
     // close every remaining file and free remaining pointers!
     // cleaning up ;-)
-    
+
     //close all files
     if (ARG_typeofrun==0){// dcd-file
         close_file_read(v);
     }
-    
+
     fclose(conv_obs_file);
     fclose(pair_correl_file);
     fclose(intra_pot_file);
@@ -1032,20 +1029,22 @@ int main(int argc, char **argv) {
     fclose(convergence_intraweights);
     fclose(intra_interactions_file);
     fclose(conv_intraobs_file);
-    
+
     // very last file to close
     fclose(output_file);
-    
-    
-    
+
+
+
     //-----------------------------
     // free pointers
-    
-    
+
+
     // free general variables
     free(normal_obs.err_ee2);
     free(normal_obs.err_rgyr);
-    
+
+    free(log_attempts);
+
     // torsion angles
     if (ARG_torsion==1) {
         free(normal_obs.err_pt);
@@ -1055,7 +1054,7 @@ int main(int argc, char **argv) {
             }
         }
     }
-    
+
     // D-SASA
     if (ARG_sasa==1) {
         free(normal_obs.err_dsasa);
@@ -1065,7 +1064,7 @@ int main(int argc, char **argv) {
             }
         }
     }
-    
+
     // pair correlation function
     if (ARG_pair_correlation==1) {
         free(pair_correlation_obs);
@@ -1076,9 +1075,9 @@ int main(int argc, char **argv) {
             }
         }
     }
-    
+
     free(attempts_successes);
-    
+
     // free arrays which held polymer coordinates
     for (int dim1=0; dim1<ARG_numberofbeads;dim1++){
         free(int_polymer[dim1]);
@@ -1086,9 +1085,9 @@ int main(int argc, char **argv) {
     }
     free(int_polymer);
     free(double_polymer);
-    
-    
-    
+
+
+
     // free building blocks
     if (ARG_typeofrun==13 || ARG_typeofrun==14 || ARG_typeofrun==23 || ARG_typeofrun==24 || ARG_typeofrun==33 || ARG_typeofrun==34){
         for (int dim1=0; dim1<numberofbricks; ++dim1) {
@@ -1099,16 +1098,16 @@ int main(int argc, char **argv) {
         }
         free(building_bricks);
     }
-    
-    
-    
+
+
+
     // free potential variables
     if (ARG_intra_potential > 0){
         switch (ARG_intra_potential) {
             case 1:
                 free(intra_sum_of_boltzfactors[0]);
                 break;
-                
+
             case 2:
                 for (int dim1=0; dim1<100; dim1++){
                     free(intra_sum_of_boltzfactors[dim1]);
@@ -1128,26 +1127,13 @@ int main(int argc, char **argv) {
         free(intra_parameter1);
         free(intra_parameter2);
     }
-    
-    
-    
 
 
 
-    
+
+
+
+
     // end of programm
     return EXIT_SUCCESS;
 }
-
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-

--- a/src/read_dcd.c
+++ b/src/read_dcd.c
@@ -37,7 +37,7 @@
 
 
 #include <stdio.h>
-#include <stdlib.h> 
+#include <stdlib.h>
 #include <math.h>
 #include "endianswap.h"
 #include "read_dcd.h"
@@ -83,9 +83,9 @@ CharmmPSF * ReadPSFfile(FILE *Inp, int *P_natom);
 
 
 /* print DCD error in a human readable way */
-static void print_dcderror(const char *func, int errcode) {
+void print_dcderror(const char *func, int errcode) {
     const char *errstr;
-    
+
     switch (errcode) {
         case DCD_EOF:         errstr = "end of file"; break;
         case DCD_DNE:         errstr = "file not found"; break;
@@ -101,7 +101,7 @@ static void print_dcderror(const char *func, int errcode) {
             errstr = "no error";
             break;
     }
-    //  printf("dcdplugin) %s: %s\n", func, errstr);
+    printf("dcdplugin) %s: %s\n", func, errstr);
 }
 
 
@@ -119,7 +119,7 @@ static void print_dcderror(const char *func, int errcode) {
  *               *reverse set to one if reverse-endian, zero if not.
  *               *charmm set to internal code for handling charmm data.
  */
-static int read_dcdheader(fio_fd fd, int *N, int *NSET, int *ISTART,
+int read_dcdheader(fio_fd fd, int *N, int *NSET, int *ISTART,
                           int *NSAVC, double *DELTA, int *NAMNF,
                           int **FREEINDEXES, float **fixedcoords, int *reverseEndian,
                           int *charmm)
@@ -130,13 +130,13 @@ static int read_dcdheader(fio_fd fd, int *N, int *NSET, int *ISTART,
     int NTITLE;
     int dcdcordmagic;
     char *corp = (char *) &dcdcordmagic;
-    
+
     /* coordinate dcd file magic string 'CORD' */
     corp[0] = 'C';
     corp[1] = 'O';
     corp[2] = 'R';
     corp[3] = 'D';
-    
+
     /* First thing in the file should be an 84.
      * some 64-bit compiles have a 64-bit record length indicator,
      * so we have to read two ints and check in a more complicated
@@ -144,7 +144,7 @@ static int read_dcdheader(fio_fd fd, int *N, int *NSET, int *ISTART,
     ret_val = READ(fd, input_integer, 2*sizeof(unsigned int));
     CHECK_FREAD(ret_val, "reading first int from dcd file");
     CHECK_FEOF(ret_val, "reading first int from dcd file");
-    
+
     /* Check magic number in file header and determine byte order*/
     if ((input_integer[0]+input_integer[1]) == 84) {
         *reverseEndian=0;
@@ -173,11 +173,11 @@ static int read_dcdheader(fio_fd fd, int *N, int *NSET, int *ISTART,
                 printf("dcdplugin)   [0]: %10d  [1]: %10d\n", input_integer[0], input_integer[1]);
                 printf("dcdplugin)   [0]: 0x%08x  [1]: 0x%08x\n", input_integer[0], input_integer[1]);
                 return DCD_BADFORMAT;
-                
+
             }
         }
     }
-    
+
     /* check for magic string, in case of long record markers */
     if (rec_scale == RECSCALE64BIT) {
         ret_val = READ(fd, input_integer, sizeof(unsigned int));
@@ -186,12 +186,12 @@ static int read_dcdheader(fio_fd fd, int *N, int *NSET, int *ISTART,
             return DCD_BADFORMAT;
         }
     }
-    
+
     /* Buffer the entire header for random access */
     ret_val = READ(fd, hdrbuf, 80);
     CHECK_FREAD(ret_val, "buffering header");
     CHECK_FEOF(ret_val, "buffering header");
-    
+
     /* CHARMm-genereate DCD files set the last integer in the     */
     /* header, which is unused by X-PLOR, to its version number.  */
     /* Checking if this is nonzero tells us this is a CHARMm file */
@@ -200,17 +200,17 @@ static int read_dcdheader(fio_fd fd, int *N, int *NSET, int *ISTART,
         (*charmm) = DCD_IS_CHARMM;
         if (*((int *) (hdrbuf + 40)) != 0)
             (*charmm) |= DCD_HAS_EXTRA_BLOCK;
-        
+
         if (*((int *) (hdrbuf + 44)) == 1)
             (*charmm) |= DCD_HAS_4DIMS;
-        
+
         if (rec_scale == RECSCALE64BIT)
             (*charmm) |= DCD_HAS_64BIT_REC;
-        
+
     } else {
         (*charmm) = DCD_IS_XPLOR; /* must be an X-PLOR format DCD file */
     }
-    
+
     if (*charmm & DCD_IS_CHARMM) {
         /* CHARMM and NAMD versions 2.1b1 and later */
         //    printf("dcdplugin) CHARMM format DCD file (also NAMD 2.1 and later)\n");
@@ -218,23 +218,23 @@ static int read_dcdheader(fio_fd fd, int *N, int *NSET, int *ISTART,
         /* CHARMM and NAMD versions prior to 2.1b1  */
         //    printf("dcdplugin) X-PLOR format DCD file (also NAMD 2.0 and earlier)\n");
     }
-    
+
     /* Store the number of sets of coordinates (NSET) */
     (*NSET) = *((int *) (hdrbuf));
     if (*reverseEndian) swap4_unaligned(NSET, 1);
-    
+
     /* Store ISTART, the starting timestep */
     (*ISTART) = *((int *) (hdrbuf + 4));
     if (*reverseEndian) swap4_unaligned(ISTART, 1);
-    
+
     /* Store NSAVC, the number of timesteps between dcd saves */
     (*NSAVC) = *((int *) (hdrbuf + 8));
     if (*reverseEndian) swap4_unaligned(NSAVC, 1);
-    
+
     /* Store NAMNF, the number of fixed atoms */
     (*NAMNF) = *((int *) (hdrbuf + 32));
     if (*reverseEndian) swap4_unaligned(NAMNF, 1);
-    
+
     /* Read in the timestep, DELTA */
     /* Note: DELTA is stored as a double with X-PLOR but as a float with CHARMm */
     if ((*charmm) & DCD_IS_CHARMM) {
@@ -242,19 +242,19 @@ static int read_dcdheader(fio_fd fd, int *N, int *NSET, int *ISTART,
         ftmp = *((float *)(hdrbuf+36)); /* is this safe on Alpha? */
         if (*reverseEndian)
             swap4_aligned(&ftmp, 1);
-        
+
         *DELTA = (double)ftmp;
     } else {
         (*DELTA) = *((double *)(hdrbuf + 36));
         if (*reverseEndian) swap8_unaligned(DELTA, 1);
     }
-    
+
     /* Get the end size of the first block */
     ret_val = READ(fd, input_integer, rec_scale*sizeof(int));
     CHECK_FREAD(ret_val, "reading second 84 from dcd file");
     CHECK_FEOF(ret_val, "reading second 84 from dcd file");
     if (*reverseEndian) swap4_aligned(input_integer, rec_scale);
-    
+
     if (rec_scale == RECSCALE64BIT) {
         if ((input_integer[0]+input_integer[1]) != 84) {
             return DCD_BADFORMAT;
@@ -264,26 +264,26 @@ static int read_dcdheader(fio_fd fd, int *N, int *NSET, int *ISTART,
             return DCD_BADFORMAT;
         }
     }
-    
+
     /* Read in the size of the next block */
     input_integer[1] = 0;
     ret_val = READ(fd, input_integer, rec_scale*sizeof(int));
     CHECK_FREAD(ret_val, "reading size of title block");
     CHECK_FEOF(ret_val, "reading size of title block");
     if (*reverseEndian) swap4_aligned(input_integer, rec_scale);
-    
+
     if ((((input_integer[0]+input_integer[1])-4) % 80) == 0) {
         /* Read NTITLE, the number of 80 character title strings there are */
         ret_val = READ(fd, &NTITLE, sizeof(int));
         CHECK_FREAD(ret_val, "reading NTITLE");
         CHECK_FEOF(ret_val, "reading NTITLE");
         if (*reverseEndian) swap4_aligned(&NTITLE, 1);
-        
+
         for (i=0; i<NTITLE; i++) {
             fio_fseek(fd, 80, FIO_SEEK_CUR);
             CHECK_FEOF(ret_val, "reading TITLE");
         }
-        
+
         /* Get the ending size for this block */
         ret_val = READ(fd, input_integer, rec_scale*sizeof(int));
         CHECK_FREAD(ret_val, "reading size of title block");
@@ -291,91 +291,91 @@ static int read_dcdheader(fio_fd fd, int *N, int *NSET, int *ISTART,
     } else {
         return DCD_BADFORMAT;
     }
-    
+
     /* Read in an integer '4' */
     input_integer[1] = 0;
     ret_val = READ(fd, input_integer, rec_scale*sizeof(int));
-    
+
     CHECK_FREAD(ret_val, "reading a '4'");
     CHECK_FEOF(ret_val, "reading a '4'");
     if (*reverseEndian) swap4_aligned(input_integer, rec_scale);
-    
+
     if ((input_integer[0]+input_integer[1]) != 4) {
         return DCD_BADFORMAT;
     }
-    
+
     /* Read in the number of atoms */
     ret_val = READ(fd, N, sizeof(int));
     CHECK_FREAD(ret_val, "reading number of atoms");
     CHECK_FEOF(ret_val, "reading number of atoms");
     if (*reverseEndian) swap4_aligned(N, 1);
-    
+
     /* Read in an integer '4' */
     input_integer[1] = 0;
     ret_val = READ(fd, input_integer, rec_scale*sizeof(int));
     CHECK_FREAD(ret_val, "reading a '4'");
     CHECK_FEOF(ret_val, "reading a '4'");
     if (*reverseEndian) swap4_aligned(input_integer, rec_scale);
-    
+
     if ((input_integer[0]+input_integer[1]) != 4) {
         return DCD_BADFORMAT;
     }
-    
+
     *FREEINDEXES = NULL;
     *fixedcoords = NULL;
     if (*NAMNF != 0) {
         (*FREEINDEXES) = (int *) calloc(((*N)-(*NAMNF)), sizeof(int));
         if (*FREEINDEXES == NULL)
             return DCD_BADMALLOC;
-        
+
         *fixedcoords = (float *) calloc((*N)*4 - (*NAMNF), sizeof(float));
         if (*fixedcoords == NULL)
             return DCD_BADMALLOC;
-        
+
         /* Read in index array size */
         input_integer[1]=0;
         ret_val = READ(fd, input_integer, rec_scale*sizeof(int));
         CHECK_FREAD(ret_val, "reading size of index array");
         CHECK_FEOF(ret_val, "reading size of index array");
         if (*reverseEndian) swap4_aligned(input_integer, rec_scale);
-        
+
         if ((input_integer[0]+input_integer[1]) != ((*N)-(*NAMNF))*4) {
             return DCD_BADFORMAT;
         }
-        
+
         ret_val = READ(fd, (*FREEINDEXES), ((*N)-(*NAMNF))*sizeof(int));
         CHECK_FREAD(ret_val, "reading size of index array");
         CHECK_FEOF(ret_val, "reading size of index array");
-        
+
         if (*reverseEndian)
             swap4_aligned((*FREEINDEXES), ((*N)-(*NAMNF)));
-        
+
         input_integer[1]=0;
         ret_val = READ(fd, input_integer, rec_scale*sizeof(int));
         CHECK_FREAD(ret_val, "reading size of index array");
         CHECK_FEOF(ret_val, "reading size of index array");
         if (*reverseEndian) swap4_aligned(input_integer, rec_scale);
-        
+
         if ((input_integer[0]+input_integer[1]) != ((*N)-(*NAMNF))*4) {
             return DCD_BADFORMAT;
         }
     }
-    
+
     return DCD_SUCCESS;
 }
 
 
 
-static int read_charmm_extrablock(fio_fd fd, int charmm, int reverseEndian,
+int read_charmm_extrablock(fio_fd fd, int charmm, int reverseEndian,
                                   float *unitcell) {
     int i, input_integer[2], rec_scale;
-    
+
     if (charmm & DCD_HAS_64BIT_REC) {
         rec_scale = RECSCALE64BIT;
     } else {
         rec_scale = RECSCALE32BIT;
     }
-    
+
     if ((charmm & DCD_IS_CHARMM) && (charmm & DCD_HAS_EXTRA_BLOCK)) {
         /* Leading integer must be 48 */
         input_integer[1] = 0;
@@ -394,55 +394,55 @@ static int read_charmm_extrablock(fio_fd fd, int charmm, int reverseEndian,
         }
         if (fio_fread(input_integer, sizeof(int), rec_scale, fd) != rec_scale) return DCD_BADREAD;
     }
-    
+
     return DCD_SUCCESS;
 }
 
-static int read_fixed_atoms(fio_fd fd, int N, int num_free, const int *indexes,
+int read_fixed_atoms(fio_fd fd, int N, int num_free, const int *indexes,
                             int reverseEndian, const float *fixedcoords,
                             float *freeatoms, float *pos, int charmm) {
     int i, input_integer[2], rec_scale;
-    
+
     if(charmm & DCD_HAS_64BIT_REC) {
         rec_scale=RECSCALE64BIT;
     } else {
         rec_scale=RECSCALE32BIT;
     }
-    
+
     /* Read leading integer */
     input_integer[1]=0;
     if (fio_fread(input_integer, sizeof(int), rec_scale, fd) != rec_scale) return DCD_BADREAD;
     if (reverseEndian) swap4_aligned(input_integer, rec_scale);
     if ((input_integer[0]+input_integer[1]) != 4*num_free) return DCD_BADFORMAT;
-    
+
     /* Read free atom coordinates */
     if (fio_fread(freeatoms, 4*num_free, 1, fd) != 1) return DCD_BADREAD;
     if (reverseEndian)
         swap4_aligned(freeatoms, num_free);
-    
+
     /* Copy fixed and free atom coordinates into position buffer */
     memcpy(pos, fixedcoords, 4*N);
     for (i=0; i<num_free; i++)
         pos[indexes[i]-1] = freeatoms[i];
-    
+
     /* Read trailing integer */
     input_integer[1]=0;
     if (fio_fread(input_integer, sizeof(int), rec_scale, fd) != rec_scale) return DCD_BADREAD;
     if (reverseEndian) swap4_aligned(input_integer, rec_scale);
     if ((input_integer[0]+input_integer[1]) != 4*num_free) return DCD_BADFORMAT;
-    
+
     return DCD_SUCCESS;
 }
 
-static int read_charmm_4dim(fio_fd fd, int charmm, int reverseEndian) {
+int read_charmm_4dim(fio_fd fd, int charmm, int reverseEndian) {
     int input_integer[2],rec_scale;
-    
+
     if (charmm & DCD_HAS_64BIT_REC) {
         rec_scale=RECSCALE64BIT;
     } else {
         rec_scale=RECSCALE32BIT;
     }
-    
+
     /* If this is a CHARMm file and contains a 4th dimension block, */
     /* we must skip past it to avoid problems                       */
     if ((charmm & DCD_IS_CHARMM) && (charmm & DCD_HAS_4DIMS)) {
@@ -452,7 +452,7 @@ static int read_charmm_4dim(fio_fd fd, int charmm, int reverseEndian) {
         if (fio_fseek(fd, (input_integer[0]+input_integer[1]), FIO_SEEK_CUR)) return DCD_BADREAD;
         if (fio_fread(input_integer, sizeof(int), rec_scale, fd) != rec_scale) return DCD_BADREAD;
     }
-    
+
     return DCD_SUCCESS;
 }
 
@@ -470,64 +470,64 @@ static int read_charmm_4dim(fio_fd fd, int charmm, int reverseEndian) {
  * Side effects: x, y, z contain the coordinates for the timestep read.
  *               unitcell holds unit cell data if present.
  */
-static int read_dcdstep(fio_fd fd, int N, float *X, float *Y, float *Z,
+int read_dcdstep(fio_fd fd, int N, float *X, float *Y, float *Z,
                         float *unitcell, int num_fixed,
                         int first, int *indexes, float *fixedcoords,
                         int reverseEndian, int charmm) {
     int ret_val, rec_scale;   /* Return value from read */
-    
+
     if (charmm & DCD_HAS_64BIT_REC) {
         rec_scale=RECSCALE64BIT;
     } else {
         rec_scale=RECSCALE32BIT;
     }
-    
+
     if ((num_fixed==0) || first) {
         /* temp storage for reading formatting info */
         /* note: has to be max size we'll ever use  */
         int tmpbuf[6*RECSCALEMAX];
-        
+
         fio_iovec iov[7];   /* I/O vector for fio_readv() call          */
         fio_size_t readlen; /* number of bytes actually read            */
         int i;
-        
+
         /* if there are no fixed atoms or this is the first timestep read */
         /* then we read all coordinates normally.                         */
-        
+
         /* read the charmm periodic cell information */
         /* XXX this too should be read together with the other items in a */
         /*     single fio_readv() call in order to prevent lots of extra  */
         /*     kernel/user context switches.                              */
         ret_val = read_charmm_extrablock(fd, charmm, reverseEndian, unitcell);
         if (ret_val) return ret_val;
-        
+
         /* setup the I/O vector for the call to fio_readv() */
         iov[0].iov_base = (fio_caddr_t) &tmpbuf[0]; /* read format integer    */
         iov[0].iov_len  = rec_scale*sizeof(int);
-        
+
         iov[1].iov_base = (fio_caddr_t) X;          /* read X coordinates     */
         iov[1].iov_len  = sizeof(float)*N;
-        
+
         iov[2].iov_base = (fio_caddr_t) &tmpbuf[1*rec_scale]; /* read 2 format integers */
         iov[2].iov_len  = rec_scale*sizeof(int) * 2;
-        
+
         iov[3].iov_base = (fio_caddr_t) Y;          /* read Y coordinates     */
         iov[3].iov_len  = sizeof(float)*N;
-        
+
         iov[4].iov_base = (fio_caddr_t) &tmpbuf[3*rec_scale]; /* read 2 format integers */
         iov[4].iov_len  = rec_scale*sizeof(int) * 2;
-        
+
         iov[5].iov_base = (fio_caddr_t) Z;          /* read Y coordinates     */
         iov[5].iov_len  = sizeof(float)*N;
-        
+
         iov[6].iov_base = (fio_caddr_t) &tmpbuf[5*rec_scale]; /* read format integer    */
         iov[6].iov_len  = rec_scale*sizeof(int);
-        
+
         readlen = fio_readv(fd, &iov[0], 7);
-        
+
         if (readlen != (rec_scale*6*sizeof(int) + 3*N*sizeof(float)))
             return DCD_BADREAD;
-        
+
         /* convert endianism if necessary */
         if (reverseEndian) {
             swap4_aligned(&tmpbuf[0], rec_scale*6);
@@ -535,7 +535,7 @@ static int read_dcdstep(fio_fd fd, int N, float *X, float *Y, float *Z,
             swap4_aligned(Y, N);
             swap4_aligned(Z, N);
         }
-        
+
         /* double-check the fortran format size values for safety */
         if(rec_scale == 1) {
             for (i=0; i<6; i++) {
@@ -546,7 +546,7 @@ static int read_dcdstep(fio_fd fd, int N, float *X, float *Y, float *Z,
                 if ((tmpbuf[2*i]+tmpbuf[2*i+1]) != sizeof(float)*N) return DCD_BADFORMAT;
             }
         }
-        
+
         /* copy fixed atom coordinates into fixedcoords array if this was the */
         /* first timestep, to be used from now on.  We just copy all atoms.   */
         if (num_fixed && first) {
@@ -554,7 +554,7 @@ static int read_dcdstep(fio_fd fd, int N, float *X, float *Y, float *Z,
             memcpy(fixedcoords+N, Y, N*sizeof(float));
             memcpy(fixedcoords+2*N, Z, N*sizeof(float));
         }
-        
+
         /* read in the optional charmm 4th array */
         /* XXX this too should be read together with the other items in a */
         /*     single fio_readv() call in order to prevent lots of extra  */
@@ -578,7 +578,7 @@ static int read_dcdstep(fio_fd fd, int N, float *X, float *Y, float *Z,
         ret_val = read_charmm_4dim(fd, charmm, reverseEndian);
         if (ret_val) return ret_val;
     }
-    
+
     return DCD_SUCCESS;
 }
 
@@ -594,32 +594,32 @@ static int read_dcdstep(fio_fd fd, int N, float *X, float *Y, float *Z,
  * Side effects: One timestep will be skipped; fd will be positioned at the
  *               next timestep.
  */
-static int skip_dcdstep(fio_fd fd, int natoms, int nfixed, int charmm) {
-    
+int skip_dcdstep(fio_fd fd, int natoms, int nfixed, int charmm) {
+
     int seekoffset = 0;
     int rec_scale;
-    
+
     if (charmm & DCD_HAS_64BIT_REC) {
         rec_scale=RECSCALE64BIT;
     } else {
         rec_scale=RECSCALE32BIT;
     }
-    
+
     /* Skip charmm extra block */
     if ((charmm & DCD_IS_CHARMM) && (charmm & DCD_HAS_EXTRA_BLOCK)) {
         seekoffset += 4*rec_scale + 48 + 4*rec_scale;
     }
-    
+
     /* For each atom set, seek past an int, the free atoms, and another int. */
     seekoffset += 3 * (2*rec_scale + natoms - nfixed) * 4;
-    
+
     /* Assume that charmm 4th dim is the same size as the other three. */
     if ((charmm & DCD_IS_CHARMM) && (charmm & DCD_HAS_4DIMS)) {
         seekoffset += (2*rec_scale + natoms - nfixed) * 4;
     }
-    
+
     if (fio_fseek(fd, seekoffset, FIO_SEEK_CUR)) return DCD_BADEOF;
-    
+
     return DCD_SUCCESS;
 }
 
@@ -642,7 +642,7 @@ static int write_dcdstep(fio_fd fd, int curframe, int curstep, int N,
                          const float *X, const float *Y, const float *Z,
                          const double *unitcell, int charmm) {
     int out_integer;
-    
+
     if (charmm) {
         // write out optional unit cell
         if (unitcell != NULL) {
@@ -652,7 +652,7 @@ static int write_dcdstep(fio_fd fd, int curframe, int curstep, int N,
             fio_write_int32(fd, out_integer);
         }
     }
-    
+
     // write out coordinates
     out_integer = N*4; // N*4 bytes per X/Y/Z array (N floats per array)
     fio_write_int32(fd, out_integer);
@@ -664,14 +664,14 @@ static int write_dcdstep(fio_fd fd, int curframe, int curstep, int N,
     fio_write_int32(fd, out_integer);
     if (fio_fwrite((void *) Z, out_integer, 1, fd) != 1) return DCD_BADWRITE;
     fio_write_int32(fd, out_integer);
-    
+
     // update the DCD header information
     fio_fseek(fd, NFILE_POS, FIO_SEEK_SET);
     fio_write_int32(fd, curframe);
     fio_fseek(fd, NSTEP_POS, FIO_SEEK_SET);
     fio_write_int32(fd, curstep);
     fio_fseek(fd, 0, FIO_SEEK_END);
-    
+
     return DCD_SUCCESS;
 } */
 
@@ -689,8 +689,8 @@ static int write_dcdstep(fio_fd fd, int curframe, int curstep, int N,
  */
 
 /* At the moment there is no need to write dcd
- 
-static int write_dcdheader(fio_fd fd, const char *remarks, int N,
+
+int write_dcdheader(fio_fd fd, const char *remarks, int N,
                            int ISTART, int NSAVC, double DELTA, int with_unitcell,
                            int charmm) {
     int out_integer;
@@ -699,7 +699,7 @@ static int write_dcdheader(fio_fd fd, const char *remarks, int N,
     time_t cur_time;
     struct tm *tmbuf;
     char time_str[81];
-    
+
     out_integer = 84;
     WRITE(fd, (char *) & out_integer, sizeof(int));
     strcpy(title_string, "CORD");
@@ -733,28 +733,28 @@ static int write_dcdheader(fio_fd fd, const char *remarks, int N,
     fio_write_int32(fd, 0);
     fio_write_int32(fd, 0);
     if (charmm) {
-        fio_write_int32(fd, 24); // Pretend to be CHARMM version 24 
+        fio_write_int32(fd, 24); // Pretend to be CHARMM version 24
     } else {
         fio_write_int32(fd, 0);
     }
     fio_write_int32(fd, 84);
     fio_write_int32(fd, 164);
     fio_write_int32(fd, 2);
-    
+
     strncpy(title_string, remarks, 80);
     title_string[79] = '\0';
     WRITE(fd, title_string, 80);
-    
+
     cur_time=time(NULL);
     tmbuf=localtime(&cur_time);
     strftime(time_str, 80, "REMARKS Created %d %B, %Y at %R", tmbuf);
     WRITE(fd, time_str, 80);
-    
+
     fio_write_int32(fd, 164);
     fio_write_int32(fd, 4);
     fio_write_int32(fd, N);
     fio_write_int32(fd, 4);
-    
+
     return DCD_SUCCESS;
 }*/
 
@@ -765,7 +765,7 @@ static int write_dcdheader(fio_fd fd, const char *remarks, int N,
  * Output: None
  * Side effects: Space pointed to by freeind is freed if necessary.
  */
-static void close_dcd_read(int *indexes, float *fixedcoords) {
+void close_dcd_read(int *indexes, float *fixedcoords) {
     free(indexes);
     free(fixedcoords);
 }
@@ -780,25 +780,25 @@ void *open_dcd_read(const char *path, const char *filetype,
     fio_fd fd;
     int rc;
     struct stat stbuf;
-    
+
     if (!path) return NULL;
-    
+
     /* See if the file exists, and get its size */
     memset(&stbuf, 0, sizeof(struct stat));
     if (stat(path, &stbuf)) {
         printf("dcdplugin) Could not access file '%s'.\n", path);
         return NULL;
     }
-    
+
     if (fio_open(path, FIO_READ, &fd) < 0) {
         printf("dcdplugin) Could not open file '%s' for reading.\n", path);
         return NULL;
     }
-    
+
     dcd = (dcdhandle *)malloc(sizeof(dcdhandle));
     memset(dcd, 0, sizeof(dcdhandle));
     dcd->fd = fd;
-    
+
     if ((rc = read_dcdheader(dcd->fd, &dcd->natoms, &dcd->nsets, &dcd->istart,
                              &dcd->nsavc, &dcd->delta, &dcd->nfixed, &dcd->freeind,
                              &dcd->fixedcoords, &dcd->reverse, &dcd->charmm))) {
@@ -807,7 +807,7 @@ void *open_dcd_read(const char *path, const char *filetype,
         free(dcd);
         return NULL;
     }
-    
+
     /*
      * Check that the file is big enough to really hold the number of sets
      * it claims to have.  Then we'll use nsets to keep track of where EOF
@@ -817,20 +817,20 @@ void *open_dcd_read(const char *path, const char *filetype,
         fio_size_t ndims, firstframesize, framesize, extrablocksize;
         fio_size_t trjsize, filesize, curpos;
         int newnsets;
-        
+
         extrablocksize = dcd->charmm & DCD_HAS_EXTRA_BLOCK ? 48 + 8 : 0;
         ndims = dcd->charmm & DCD_HAS_4DIMS ? 4 : 3;
         firstframesize = (dcd->natoms+2) * ndims * sizeof(float) + extrablocksize;
         framesize = (dcd->natoms-dcd->nfixed+2) * ndims * sizeof(float)
         + extrablocksize;
-        
+
         /*
          * It's safe to use ftell, even though ftell returns a long, because the
          * header size is < 4GB.
          */
-        
+
         curpos = fio_ftell(dcd->fd); /* save current offset (end of header) */
-        
+
 #if defined(_MSC_VER) && defined(FASTIO_NATIVEWIN32)
         /* the stat() call is not 64-bit savvy on Windows             */
         /* so we have to use the fastio fseek/ftell routines for this */
@@ -848,17 +848,17 @@ void *open_dcd_read(const char *path, const char *filetype,
             free(dcd);
             return NULL;
         }
-        
+
         newnsets = trjsize / framesize + 1;
-        
+
         if (dcd->nsets > 0 && newnsets != dcd->nsets) {
             //      printf("dcdplugin) Warning: DCD header claims %d frames, file size indicates there are actually %d frames\n", dcd->nsets, newnsets);
         }
-        
+
         dcd->nsets = newnsets;
         dcd->setsread = 0;
     }
-    
+
     dcd->first = 1;
     dcd->x = (float *)malloc(dcd->natoms * sizeof(float));
     dcd->y = (float *)malloc(dcd->natoms * sizeof(float));
@@ -887,7 +887,7 @@ static int read_next_timestep(void *v, int natoms, molfile_timestep_t *ts) {
     unitcell[0] = unitcell[2] = unitcell[5] = 1.0f;
     unitcell[1] = unitcell[3] = unitcell[4] = 90.0f;
     dcd = (dcdhandle *)v;
-    
+
     /* Check for EOF here; that way all EOF's encountered later must be errors */
     if (dcd->setsread == dcd->nsets) return MOLFILE_EOF;
     dcd->setsread++;
@@ -912,7 +912,7 @@ static int read_next_timestep(void *v, int natoms, molfile_timestep_t *ts) {
         print_dcderror("read_dcdstep", rc);
         return MOLFILE_ERROR;
     }
-    
+
     /* copy timestep data from plugin-local buffers to VMD's buffer */
     /* XXX
      *   This code is still the root of all evil.  Just doing this extra copy
@@ -927,18 +927,18 @@ static int read_next_timestep(void *v, int natoms, molfile_timestep_t *ts) {
         const float *bufx = dcd->x;
         const float *bufy = dcd->y;
         const float *bufz = dcd->z;
-        
+
         for (i=0, j=0; i<natoms; i++, j+=3) {
             nts[j    ] = bufx[i];
             nts[j + 1] = bufy[i];
             nts[j + 2] = bufz[i];
         }
     }
-    
+
     ts->A = unitcell[0];
     ts->B = unitcell[2];
     ts->C = unitcell[5];
-    
+
     if (unitcell[1] >= -1.0 && unitcell[1] <= 1.0 &&
         unitcell[3] >= -1.0 && unitcell[3] <= 1.0 &&
         unitcell[4] >= -1.0 && unitcell[4] <= 1.0) {
@@ -956,7 +956,7 @@ static int read_next_timestep(void *v, int natoms, molfile_timestep_t *ts) {
         ts->beta  = unitcell[3]; /* angle between A and C */
         ts->gamma = unitcell[1]; /* angle between A and B */
     }
-    
+
     return MOLFILE_SUCCESS;
 }
 
@@ -972,7 +972,7 @@ void close_file_read(void *v) {
 }
 
 /* At the moment DCDs souhld only be read
-static void *open_dcd_write(const char *path, const char *filetype,
+void *open_dcd_write(const char *path, const char *filetype,
                             int natoms) {
     dcdhandle *dcd;
     fio_fd fd;
@@ -981,20 +981,20 @@ static void *open_dcd_write(const char *path, const char *filetype,
     double delta;
     int with_unitcell;
     int charmm;
-    
+
     if (fio_open(path, FIO_WRITE, &fd) < 0) {
         printf("dcdplugin) Could not open file '%s' for writing\n", path);
         return NULL;
     }
-    
+
     dcd = (dcdhandle *)malloc(sizeof(dcdhandle));
     memset(dcd, 0, sizeof(dcdhandle));
     dcd->fd = fd;
-    
+
     istart = 0;             // starting timestep of DCD file
     nsavc = 1;              // number of timesteps between written DCD frames
     delta = 1.0;            // length of a timestep
-    
+
     if (getenv("VMDDCDWRITEXPLORFORMAT") != NULL) {
         with_unitcell = 0;      // no unit cell info
         charmm = DCD_IS_XPLOR;  // X-PLOR format
@@ -1006,17 +1006,17 @@ static void *open_dcd_write(const char *path, const char *filetype,
         if (with_unitcell)
             charmm |= DCD_HAS_EXTRA_BLOCK;
     }
-    
+
     rc = write_dcdheader(dcd->fd, "Created by DCD plugin", natoms,
                          istart, nsavc, delta, with_unitcell, charmm);
-    
+
     if (rc < 0) {
         print_dcderror("write_dcdheader", rc);
         fio_fclose(dcd->fd);
         free(dcd);
         return NULL;
     }
-    
+
     dcd->natoms = natoms;
     dcd->nsets = 0;
     dcd->istart = istart;
@@ -1040,7 +1040,7 @@ static int write_timestep(void *v, const molfile_timestep_t *ts) {
     double unitcell[6];
     unitcell[0] = unitcell[2] = unitcell[5] = 1.0f;
     unitcell[1] = unitcell[3] = unitcell[4] = 90.0f;
-    
+
     // copy atom coords into separate X/Y/Z arrays for writing
     for (i=0; i<dcd->natoms; i++) {
         dcd->x[i] = *(pos++);
@@ -1049,14 +1049,14 @@ static int write_timestep(void *v, const molfile_timestep_t *ts) {
     }
     dcd->nsets++;
     curstep = dcd->istart + dcd->nsets * dcd->nsavc;
-    
+
     unitcell[0] = ts->A;
     unitcell[2] = ts->B;
     unitcell[5] = ts->C;
     unitcell[1] = sin((M_PI_2 / 90.0) * (90.0 - ts->gamma)); // cosAB
     unitcell[3] = sin((M_PI_2 / 90.0) * (90.0 - ts->beta));  // cosAC
     unitcell[4] = sin((M_PI_2 / 90.0) * (90.0 - ts->alpha)); // cosBC
-    
+
     rc = write_dcdstep(dcd->fd, dcd->nsets, curstep, dcd->natoms,
                        dcd->x, dcd->y, dcd->z,
                        dcd->with_unitcell ? unitcell : NULL,
@@ -1065,7 +1065,7 @@ static int write_timestep(void *v, const molfile_timestep_t *ts) {
         print_dcderror("write_dcdstep", rc);
         return MOLFILE_ERROR;
     }
-    
+
     return MOLFILE_SUCCESS;
 }
  */
@@ -1080,24 +1080,24 @@ static int write_timestep(void *v, vector < vector < Vec3 > >& lcoord)
 {
     dcdhandle *dcd = (dcdhandle *)v;
     int i, rc, curstep, curindex;
-    
+
     double unitcell[6];
     unitcell[0] = unitcell[2] = unitcell[5] = 1.0f;
     unitcell[1] = unitcell[3] = unitcell[4] = 0.0f;
-    
+
     // all frames
     for (curindex = 0; curindex < lcoord.size(); curindex++)
     {
         for (i=0; i<dcd->natoms; i++)
         {
-            dcd->x[i] = lcoord[curindex][i].x; 
-            dcd->y[i] = lcoord[curindex][i].y; 
-            dcd->z[i] = lcoord[curindex][i].z; 
+            dcd->x[i] = lcoord[curindex][i].x;
+            dcd->y[i] = lcoord[curindex][i].y;
+            dcd->z[i] = lcoord[curindex][i].z;
         }
         dcd->nsets++;
         curstep = dcd->istart + dcd->nsets * dcd->nsavc;
-        
-        rc = write_dcdstep(dcd->fd, dcd->nsets, curstep, dcd->natoms, 
+
+        rc = write_dcdstep(dcd->fd, dcd->nsets, curstep, dcd->natoms,
                            dcd->x, dcd->y, dcd->z, dcd->with_unitcell ? unitcell : NULL, dcd->charmm);
         if (rc < 0) {
             print_dcderror("write_dcdstep", rc);
@@ -1115,7 +1115,7 @@ static int write_timestep(void *v, vector < vector < Vec3 > >& lcoord, vector <i
     double unitcell[6];
     unitcell[0] = unitcell[2] = unitcell[5] = 1.0f;
     unitcell[1] = unitcell[3] = unitcell[4] = 0.0f;
-    
+
     // only allowed frames (usealloweddcd=1) or disallowed frames (usealloweddcd=2)
     int allowordisallow=0;
     if (usealloweddcd==1) {allowordisallow=1;} // allowed
@@ -1126,16 +1126,16 @@ static int write_timestep(void *v, vector < vector < Vec3 > >& lcoord, vector <i
             if (conformations_alloweddcd[curindex]==allowordisallow) {
                 for (i=0; i<dcd->natoms; i++)
                 {
-                    dcd->x[i] = lcoord[curindex][i].x; 
-                    dcd->y[i] = lcoord[curindex][i].y; 
-                    dcd->z[i] = lcoord[curindex][i].z; 
+                    dcd->x[i] = lcoord[curindex][i].x;
+                    dcd->y[i] = lcoord[curindex][i].y;
+                    dcd->z[i] = lcoord[curindex][i].z;
                 }
                 dcd->nsets++;
                 curstep = dcd->istart + dcd->nsets * dcd->nsavc;
-                
-                rc = write_dcdstep(dcd->fd, dcd->nsets, curstep, dcd->natoms, 
+
+                rc = write_dcdstep(dcd->fd, dcd->nsets, curstep, dcd->natoms,
                                    dcd->x, dcd->y, dcd->z, dcd->with_unitcell ? unitcell : NULL, dcd->charmm);
-                
+
                 if (rc < 0) {
                     print_dcderror("write_dcdstep", rc);
                     return MOLFILE_ERROR;
@@ -1145,11 +1145,11 @@ static int write_timestep(void *v, vector < vector < Vec3 > >& lcoord, vector <i
     }
     return MOLFILE_SUCCESS;
 }
- 
+
  */
 
 /*
-static void close_file_write(void *v) {
+void close_file_write(void *v) {
     dcdhandle *dcd = (dcdhandle *)v;
     fio_fclose(dcd->fd);
     free(dcd->x);
@@ -1198,7 +1198,7 @@ VMDPLUGIN_API int VMDPLUGIN_register(void *v, vmdplugin_register_cb cb) {
 VMDPLUGIN_API int VMDPLUGIN_fini() {
     return VMDPLUGIN_SUCCESS;
 }
- 
+
  */
 
 
@@ -1211,7 +1211,7 @@ VMDPLUGIN_API int VMDPLUGIN_fini() {
 
 // written by Johannes Dietschreit
 void dcd_to_polymer(double (**polymer), void *v, int natoms, molfile_timestep_t *ts, dcdhandle *dcd_hadle, unsigned long i,int numberofbeads){
-    
+
     // Read in each frame and remove translation
     int rc = read_next_timestep(v, natoms, ts);
     if (rc) {
@@ -1224,24 +1224,5 @@ void dcd_to_polymer(double (**polymer), void *v, int natoms, molfile_timestep_t 
         polymer[j][1]=(dcd_hadle->y[j] - dcd_hadle->y[0]);
         polymer[j][2]=(dcd_hadle->z[j] - dcd_hadle->z[0]);
     }
-    
+
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Primary fixes are:
* Marking global variables defined in headers as `extern`
* Eliminating some extraneous `static` qualifiers
* Dropping some unused variables
* Commenting-out some unused functions
* Ensuring that memory is freed as appropriate
* Switching to the CMake build system